### PR TITLE
Ensure retry on invalid assignee

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -167,12 +167,13 @@ public class QuestWorkItem
                 Value = "Closed",
             });
         }
-        var result = await questClient.CreateWorkItem(patchDocument);
+        JsonElement result = default;
         try
         {
+            result = await questClient.CreateWorkItem(patchDocument);
             var newItem = WorkItemFromJson(result);
             return newItem;
-        } catch (KeyNotFoundException)
+        } catch (InvalidOperationException)
         {
             Console.WriteLine(result.ToString());
             // This will happen when the assignee IS a Microsoft FTE,


### PR DESCRIPTION
The call to `CreateWorkItem` throws an InvalidOperationException when the assignee is a Microsoft FTE, but not in the configured AzureDevOps project. The code was already available, but the exception is now thrown from a helper method, so wasn't being triggered.

Tested on https://github.com/dotnet/docs-maui/issues/605