### PR TITLE
Switch from display name to UID

### DIFF
--- a/actions/sequester/ImportIssues/ImportIssues.csproj
+++ b/actions/sequester/ImportIssues/ImportIssues.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <AssemblyVersion>1.0.0.1</AssemblyVersion>
+    <FileVersion>1.0.0.1</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
@@ -66,5 +66,21 @@ public class JsonPatchDocument
     /// The new value.
     /// </summary>
     [JsonPropertyName("value")]
-    public required string? Value { get; init; }
+    public required object? Value { get; init; }
+}
+
+/// <summary>
+/// The fields required to Assign to an identity
+/// </summary>
+public class AzDoIdentity
+{
+    [JsonPropertyName("uniqueName")]
+    public required string UniqueName { get; init; }
+
+    [JsonPropertyName("id")]
+    public required Guid Id { get; init; }
+
+    [JsonPropertyName("descriptor")]
+    public required string Descriptor { get; init; }
+
 }

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
@@ -120,6 +120,21 @@ public sealed class QuestClient : IDisposable
         }
     }
 
+    public async Task<Guid?> GetIDFromEmail(string emailAddress)
+    {
+        string url = $"https://vssps.dev.azure.com/{_questOrg}/_apis/identities?searchFilter=General&filterValue={emailAddress}&queryMembership=None&api-version=7.1-preview.1";
+        var response = await _client.GetAsync(url);
+        var rootElement = await HandleResponseAsync(response);
+        var count = rootElement.Descendent("count").GetInt32();
+        if (count != 1)
+        {
+            return null;
+        }
+        var values = rootElement.Descendent("value");
+        var user = values.EnumerateArray().First();
+        return (user.Descendent("id").TryGetGuid(out var id)) ? id : null;
+    }
+
     /// <summary>
     /// Dispose of the embedded HTTP client.
     /// </summary>

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
@@ -137,7 +137,7 @@ public sealed class QuestClient : IDisposable
         // When retrieving the user identity, the property is called "subjectDescriptor".
         // But, when sending a user ID, the property name is "descriptor".
         var descriptor = user.Descendent("subjectDescriptor").GetString()!;
-        var identity = new AzDoIdentity { Id = id,UniqueName = uniqueName, Descriptor = descriptor };
+        var identity = new AzDoIdentity { Id = id, UniqueName = uniqueName, Descriptor = descriptor };
         return success ? identity : null;
     }
 

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -228,24 +228,25 @@ public class GithubIssue
     /// Retrieve the assigned name, if an MS employee
     /// </summary>
     /// <param name="ospoClient">The Open Source program office client service.</param>
-    /// <returns>The preferred display name of the assignee</returns>
-    public async Task<string?> AuthorMicrosoftPreferredName(OspoClient ospoClient)
+    /// <returns>The email address of the assignee</returns>
+    public async Task<string?> AuthorMicrosoftEmailAddress(OspoClient ospoClient)
     {
         var identity = await ospoClient.GetAsync(Author);
-        return identity?.MicrosoftInfo?.PreferredName;
+        return identity?.MicrosoftInfo?.EmailAddress;
     }
 
     /// <summary>
     /// Retrieve the assigned name, if an MS employee
     /// </summary>
     /// <param name="ospoClient">The Open Source program office client service.</param>
-    /// <returns>The preferred display name of the assignee</returns>
-    public async Task<string?> AssignedMicrosoftPreferredName(OspoClient ospoClient)
+    /// <returns>The email address of the assignee. Null if unassigned, or the assignee is not a 
+    /// Microsoft FTE.</returns>
+    public async Task<string?> AssignedMicrosoftEmailAddress(OspoClient ospoClient)
     {
         if (Assignees.Any())
         {
             var identity = await ospoClient.GetAsync(Assignees.First());
-            return identity?.MicrosoftInfo?.PreferredName;
+            return identity?.MicrosoftInfo?.EmailAddress;
         }
         return null;
     }

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -137,7 +137,7 @@ public class QuestWorkItem
 
         // Query if the Github ID maps to an FTE id, add that one:
         var assigneeEmail = await issue.AssignedMicrosoftEmailAddress(ospoClient);
-        Guid? assigneeID = default;
+        AzDoIdentity? assigneeID = default;
         if (assigneeEmail?.Contains("@microsoft.com") == true)
         {
             assigneeID = await questClient.GetIDFromEmail(assigneeEmail);
@@ -147,7 +147,7 @@ public class QuestWorkItem
             Operation = Op.Add,
             Path = "/fields/System.AssignedTo",
             From = default,
-            Value = assigneeID?.ToString() ?? ""
+            Value = assigneeID
         };
         patchDocument.Add(assignPatch);
         /* This is ignored by Azure DevOps. It uses the PAT of the 

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -138,7 +138,7 @@ public class QuestWorkItem
         // Query if the Github ID maps to an FTE id, add that one:
         var assigneeEmail = await issue.AssignedMicrosoftEmailAddress(ospoClient);
         AzDoIdentity? assigneeID = default;
-        if (assigneeEmail?.Contains("@microsoft.com") == true)
+        if (assigneeEmail?.EndsWith("@microsoft.com") == true)
         {
             assigneeID = await questClient.GetIDFromEmail(assigneeEmail);
         }

--- a/actions/sequester/Quest2GitHub/OspoClientServices/OspoClient.cs
+++ b/actions/sequester/Quest2GitHub/OspoClientServices/OspoClient.cs
@@ -8,7 +8,7 @@ namespace Microsoft.DotnetOrg.Ospo;
 public sealed class OspoClient : IDisposable
 {
     private readonly HttpClient _httpClient;
-    private readonly Dictionary<string, OspoLink?> _allEmployeeQueries = new Dictionary<string, OspoLink?>();
+    private readonly Dictionary<string, OspoLink?> _allEmployeeQueries = new();
 
 
     public OspoClient(string token)

--- a/actions/sequester/Quest2GitHub/OspoClientServices/OspoClient.cs
+++ b/actions/sequester/Quest2GitHub/OspoClientServices/OspoClient.cs
@@ -8,6 +8,8 @@ namespace Microsoft.DotnetOrg.Ospo;
 public sealed class OspoClient : IDisposable
 {
     private readonly HttpClient _httpClient;
+    private readonly Dictionary<string, OspoLink?> _allEmployeeQueries = new Dictionary<string, OspoLink?>();
+
 
     public OspoClient(string token)
     {
@@ -29,6 +31,8 @@ public sealed class OspoClient : IDisposable
 
     public async Task<OspoLink?> GetAsync(string gitHubLogin)
     {
+        if (_allEmployeeQueries.TryGetValue(gitHubLogin, out var query))
+            return query;
         var result = await _httpClient.GetFromJsonAsync<OspoLink>(
             $"people/links/github/{gitHubLogin}", JsonSerializerOptionsDefaults.Shared);
         return result;

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -208,21 +208,21 @@ public class QuestGitHubService : IDisposable
     private async Task<QuestWorkItem?> UpdateWorkItem(QuestWorkItem questItem, GithubIssue ghIssue)
     {
         var assigneeEmail = await ghIssue.AssignedMicrosoftEmailAddress(_ospoClient);
-        Guid? assigneeID = default;
+        AzDoIdentity? assigneeID = default;
         if (assigneeEmail?.Contains("@microsoft.com") == true)
         {
             assigneeID = await _azdoClient.GetIDFromEmail(assigneeEmail);
         }
         List<JsonPatchDocument> patchDocument = new();
         JsonPatchDocument? assignPatch = default;
-        if (assigneeID != questItem.AssignedToId)
+        if (assigneeID?.Id != questItem.AssignedToId)
         {
             // build patch document for assignment.
             assignPatch = new JsonPatchDocument
             {
                 Operation = Op.Add,
                 Path = "/fields/System.AssignedTo",
-                Value = assigneeID?.ToString() ?? "",
+                Value = assigneeID,
             };
             patchDocument.Add(assignPatch);
         }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -209,7 +209,7 @@ public class QuestGitHubService : IDisposable
     {
         var assigneeEmail = await ghIssue.AssignedMicrosoftEmailAddress(_ospoClient);
         AzDoIdentity? assigneeID = default;
-        if (assigneeEmail?.Contains("@microsoft.com") == true)
+        if (assigneeEmail?.EndsWith("@microsoft.com") == true)
         {
             assigneeID = await _azdoClient.GetIDFromEmail(assigneeEmail);
         }

--- a/actions/sequester/README.md
+++ b/actions/sequester/README.md
@@ -23,6 +23,7 @@ To install the GitHub actions:
    - You'll need to add two secret tokens to access the OSPO REST APIs and Quest Azure DevOps APIs.
    - *OSPO_KEY*: Generate a PAT [here](https://ossmsft.visualstudio.com/_usersSettings/tokens). UserProfile: Read is the only access needed.
    - *QUEST_KEY*: Generate a PAT [here](https://dev.azure.com/msft-skilling/_usersSettings/tokens). WorkItems: Read/Write and Project & Team: Read/Write access are needed.
+     Identity: Read is also needed.
 1. Start applying labels.
    - Add the trigger label to any issue, and it will be imported into Quest.
 


### PR DESCRIPTION
Fixes #88

Using the displayName property is brittle. It usually worked because by default, all our AzDo instances set the displayName to match the WhoIs database. But, if they were different, it failed.

Fixes #86

Avoid excess requests by caching the results of queries to match GitHub IDs to Microsoft emails.