### PR TITLE
Make sure the email address matches the alias

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -246,7 +246,14 @@ public class GithubIssue
         if (Assignees.Any())
         {
             var identity = await ospoClient.GetAsync(Assignees.First());
-            return identity?.MicrosoftInfo?.EmailAddress;
+            // This feels like a hack, but it is necessary.
+            // The email address is the email address a person configured
+            // However, the only guaranteed way to find the person in Quest 
+            // is to use their alais as an email address. Yuck.
+            if (identity?.MicrosoftInfo?.EmailAddress?.EndsWith("@microsoft.com") == true)
+                return identity.MicrosoftInfo.Alias + "@microsoft.com";
+            else
+                return identity?.MicrosoftInfo?.EmailAddress;
         }
         return null;
     }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -237,26 +237,11 @@ public class QuestGitHubService : IDisposable
                 Value = ghIssue.IsOpen ? "Active" : "Closed",
             });
         }
-        while (patchDocument.Any())
+        if (patchDocument.Any())
         {
             var jsonDocument = await _azdoClient.PatchWorkItem(questItem.Id, patchDocument);
-            try
-            {
-                var newItem = QuestWorkItem.WorkItemFromJson(jsonDocument);
-                return newItem;
-            }
-            catch (KeyNotFoundException)
-            {
-                // This will happen when the assignee IS a Microsoft FTE,
-                // but that person isn't onboarded in Quest. (Likely a product team member, or CSE)
-
-                // So, remove the node with the Assigned to and try again:
-                if (!patchDocument.Remove(assignPatch!))
-                {
-                    // If there's no assign node, clear the doc and punt
-                    patchDocument.Clear();
-                }
-            }
+            var newItem = QuestWorkItem.WorkItemFromJson(jsonDocument);
+            return newItem;
         }
         return null;
     }


### PR DESCRIPTION
If a person has registered their vanity email in OSPO (or with GitHub), translate to their alias based email for the Quest identity query. Quest queries fail for other IDs. That would cause the updates to fail because the assigned to address was incorrect.