### PR TITLE
Add an optional `branch` param

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -7,12 +7,18 @@
     /// <param name="repo">The GutHub repository names.</param>
     /// <param name="issue">The issue number. If null, process all open issues.</param>
     /// <param name="questConfigPath">The config path. If null, use the config file in the root folder of the repository.</param>
+    /// <param name="branch">The optional branch to use. Defaults to "main" otherwise.</param>
     /// <remarks>
     /// Example command line:
     /// ImportIssues --org dotnet --repo docs --issue 31331
     /// </remarks>
     /// <returns>0</returns>
-    private static async Task<int> Main(string org, string repo, int? issue = null, string? questConfigPath = null)
+    private static async Task<int> Main(
+        string org,
+        string repo,
+        int? issue = null,
+        string? questConfigPath = null,
+        string? branch = null)
     {
         try
         {
@@ -22,6 +28,8 @@
                 repo = split[1];
             }
 
+            branch ??= "main";
+            Console.WriteLine($"Using branch: '{branch}'");
             Console.WriteLine(issue.HasValue && issue > -1
                 ? $"Processing single issue {issue.Value}: https://github.com/{org}/{repo}/issues/{issue.Value}"
                 : $"Processing all open issues: {org}/{repo}");
@@ -30,7 +38,7 @@
             if (string.IsNullOrWhiteSpace(questConfigPath) || !File.Exists(questConfigPath))
             {
                 using RawGitHubFileReader reader = new();
-                importOptions = await reader.ReadOptionsAsync(org, repo);
+                importOptions = await reader.ReadOptionsAsync(org, repo, branch);
             }
             else
             {

--- a/actions/sequester/action.yml
+++ b/actions/sequester/action.yml
@@ -13,6 +13,9 @@ inputs:
     default: 'docs'
   issue:
     description: 'An optional issue number to target when being triggered for a single issue.'
+  branch:
+    description: 'The branch to target. Assign from github.ref_name. Example, "main".'
+    default: 'main'
 
 runs:
   using: docker
@@ -24,3 +27,5 @@ runs:
     - ${{ inputs.repo }}
     - '--issue'
     - ${{ inputs.issue }}
+    - '--branch'
+    - ${{ inputs.branch }}


### PR DESCRIPTION
This is an optional param, so workflows can opt-in to specify it. But it shouldn't break existing consumers who do not pass it. Example consumer workflow would add the argument to the with section, similar to this:

```yml
      # This step occurs automatically, passing the issue number from the event
      - name: auto-sequester
        if: ${{ github.event_name != 'workflow_dispatch' }}
        id: auto-sequester
        uses: dotnet/docs-tools/actions/sequester@main
        env:
          ImportOptions__ApiKeys__GitHubToken: ${{ secrets.GITHUB_TOKEN }}
          ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_KEY }}
          ImportOptions__ApiKeys__QuestKey: ${{ secrets.QUEST_KEY }}
        with:
          org: ${{ github.repository_owner }}
          repo: ${{ github.repository }}
          issue: ${{ github.event.issue.number }}
          branch: ${{ github.ref_name }} # defaults to 'main'
```