### PR TITLE
Update Description on close

### DIFF
--- a/actions/sequester/ImportIssues/ImportIssues.csproj
+++ b/actions/sequester/ImportIssues/ImportIssues.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <AssemblyVersion>1.0.0.1</AssemblyVersion>
-    <FileVersion>1.0.0.1</FileVersion>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -174,7 +174,7 @@ public class QuestWorkItem
 
     public static string BuildDescriptionFromIssue(GithubIssue issue, string? requestLabelNodeId)
     {
-        StringBuilder body = new StringBuilder($"<p>Imported from: {issue.LinkText}</p>");
+        var body = new StringBuilder($"<p>Imported from: {issue.LinkText}</p>");
         body.AppendLine($"<p>Author: {issue.Author}</p>");
         body.AppendLine(issue.BodyHtml);
         if (issue.Labels.Any())

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -1,4 +1,7 @@
-﻿namespace Quest2GitHub.Models;
+﻿using Quest2GitHub.AzureDevOpsCommunications;
+using System.IO;
+
+namespace Quest2GitHub.Models;
 
 public class QuestWorkItem
 {
@@ -83,31 +86,7 @@ public class QuestWorkItem
         string path,
         string? requestLabelNodeId)
     {
-        StringBuilder body = new StringBuilder($"<p>Imported from: {issue.LinkText}</p>");
-        body.AppendLine($"<p>Author: {issue.Author}</p>");
-        body.AppendLine(issue.BodyHtml);
         var areaPath = $"""{questClient.QuestProject}\{path}""";
-        if (issue.Labels.Any())
-        {
-            body.AppendLine($"<p><b>Labels:</b></p>");
-            body.AppendLine("<ul>");
-            foreach (var item in issue.Labels.Where(l => l.nodeID != requestLabelNodeId))
-            {
-                body.AppendLine($"<li>#{item.name.Replace(' ', '-')}</li>");
-            }
-            body.AppendLine("</ul>");
-        }
-        if (issue.Comments.Any())
-        {
-            body.AppendLine($"<p><b>Comments:</b></p>");
-            body.AppendLine("<dl>");
-            foreach (var item in issue.Comments)
-            {
-                body.AppendLine($"<dt>{item.author}</dt>");
-                body.AppendLine($"<dd>{item.bodyHTML}</dd>");
-            }
-            body.AppendLine("</dl>");
-        }
 
         var patchDocument = new List<JsonPatchDocument>()
         {
@@ -123,7 +102,7 @@ public class QuestWorkItem
                 Operation = Op.Add,
                 Path = "/fields/System.Description",
                 From = default,
-                Value = body.ToString()
+                Value = BuildDescriptionFromIssue(issue, requestLabelNodeId)
             },
             new JsonPatchDocument
             {
@@ -191,6 +170,35 @@ public class QuestWorkItem
             result = await questClient.CreateWorkItem(patchDocument);
             return WorkItemFromJson(result);
         }
+    }
+
+    public static string BuildDescriptionFromIssue(GithubIssue issue, string? requestLabelNodeId)
+    {
+        StringBuilder body = new StringBuilder($"<p>Imported from: {issue.LinkText}</p>");
+        body.AppendLine($"<p>Author: {issue.Author}</p>");
+        body.AppendLine(issue.BodyHtml);
+        if (issue.Labels.Any())
+        {
+            body.AppendLine($"<p><b>Labels:</b></p>");
+            body.AppendLine("<ul>");
+            foreach (var item in issue.Labels.Where(l => l.nodeID != requestLabelNodeId))
+            {
+                body.AppendLine($"<li>#{item.name.Replace(' ', '-')}</li>");
+            }
+            body.AppendLine("</ul>");
+        }
+        if (issue.Comments.Any())
+        {
+            body.AppendLine($"<p><b>Comments:</b></p>");
+            body.AppendLine("<dl>");
+            foreach (var item in issue.Comments)
+            {
+                body.AppendLine($"<dt>{item.author}</dt>");
+                body.AppendLine($"<dd>{item.bodyHTML}</dd>");
+            }
+            body.AppendLine("</dl>");
+        }
+        return body.ToString();
     }
 
     /// <summary>

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -236,6 +236,18 @@ public class QuestGitHubService : IDisposable
                 Path = "/fields/System.State",
                 Value = ghIssue.IsOpen ? "Active" : "Closed",
             });
+
+            // When the issue is opened or closed, 
+            // update the description. That picks up any new
+            // labels and comments.
+            patchDocument.Add(new JsonPatchDocument
+            {
+                Operation = Op.Add,
+                Path = "/fields/System.Description",
+                From = default,
+                Value = QuestWorkItem.BuildDescriptionFromIssue(ghIssue, null)
+            });
+
         }
         if (patchDocument.Any())
         {


### PR DESCRIPTION
When the GitHub issue is closed or re-opened, update the Quest description. This will pickup any new updates to labels, comments, or the description of the GitHub issue.