### PR TITLE
clear X axis data when chart parameters change

### DIFF
--- a/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
+++ b/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
@@ -5,6 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>1e8b5bf8-1a2d-446d-9cd3-48609334c53f</UserSecretsId>
+    <AssemblyVersion>1.0.1.0</AssemblyVersion>
+    <FileVersion>1.0.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitHub.RepositoryExplorer.Client/Pages/ClassificationLineChart.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/ClassificationLineChart.razor.cs
@@ -122,6 +122,7 @@ public partial class ClassificationLineChart: ComponentBase
                 if (_issueSnapshots is { Count: > 0 })
                 {
                     _chartConfig.Data.Labels.Clear();
+                    _chartConfig.Data.XLabels.Clear();
                     foreach (var date in DateRange)
                     {
                         _chartConfig.Data.XLabels.Add(date.ToShortDateString());

--- a/GitHub.RepositoryExplorer.Client/Pages/PriorityLineChart.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/PriorityLineChart.razor.cs
@@ -122,6 +122,7 @@ public partial class PriorityLineChart: ComponentBase
                 if (_issueSnapshots is { Count: > 0 })
                 {
                     _chartConfig.Data.Labels.Clear();
+                    _chartConfig.Data.XLabels.Clear();
                     foreach (var date in DateRange)
                     {
                         _chartConfig.Data.XLabels.Add(date.ToShortDateString());

--- a/GitHub.RepositoryExplorer.Client/Pages/ProductLineChartJS.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/ProductLineChartJS.razor.cs
@@ -122,6 +122,7 @@ public partial class ProductLineChartJS : ComponentBase
                 if (_issueSnapshots is { Count: > 0 })
                 {
                     _chartConfig.Data.Labels.Clear();
+                    _chartConfig.Data.XLabels.Clear();
                     foreach (var date in DateRange)
                     {
                         _chartConfig.Data.XLabels.Add(date.ToShortDateString());

--- a/GitHub.RepositoryExplorer.Models/RepositoryLabelConfig.cs
+++ b/GitHub.RepositoryExplorer.Models/RepositoryLabelConfig.cs
@@ -31,6 +31,7 @@ public interface ILabelDefinition
 // This will be read from some config file, that somehow specifies the GitHub org and GitHub repo (maybe the config is stored there in time)
 public class IssueClassificationModel
 {
+    static readonly char[] invalidChars = { ',', '/', '\\', ':' };
 
     public Product[] Products { get; set; } = Array.Empty<Product>();
     public Classification[] Classification { get; set; } = Array.Empty<Classification>();
@@ -39,6 +40,10 @@ public class IssueClassificationModel
     public static async Task<IssueClassificationModel> CreateFromConfig(string configFolder, string organization, string repo)
     {
         // TODO: Get config file from other storage.
+        if (organization is null) throw new ArgumentNullException(nameof(organization));
+        if (repo is null) throw new ArgumentNullException(nameof(repo));
+        if (organization.IndexOfAny(invalidChars) != -1) throw new ArgumentException("organization contains invalid characters", nameof(organization));
+        if (repo.IndexOfAny(invalidChars) != -1) throw new ArgumentException("repo contains invalid characters", nameof(repo));
         var filePath = $"{organization}-{repo}.json";
         if (!string.IsNullOrEmpty(configFolder))
         {


### PR DESCRIPTION
Before this change, changing the dates for the graphs didn't clear the X axis data. The result was that the requested data took less and less of the screen space. The remainder was the blank space from the previous chart parameters.