### PR TITLE
[Whats new] Updates belong in 1 header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,7 @@ _repo.*/
 
 *.vs
 .openpublishing.buildcore.ps1
+GitHub.RepositoryExplorer.Client/Properties/ServiceDependencies/github-explorer - Web Deploy/profile.arm.json
+GitHub.RepositoryExplorer.Client/Properties/ServiceDependencies/github-explorer - Zip Deploy1/profile.arm.json
+GitHub.RepositoryExplorer.WebApi/Properties/ServiceDependencies/github-explorer-web-api - Web Deploy/profile.arm.json
+GitHub.RepositoryExplorer.WebApi/Properties/ServiceDependencies/github-explorer-web-api - Zip Deploy1/profile.arm.json

--- a/actions/sequester/Quest2GitHub.sln
+++ b/actions/sequester/Quest2GitHub.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImportIssues", "ImportIssue
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Quest2GitHub.Tests", "Quest2GitHub.Tests\Quest2GitHub.Tests.csproj", "{02A9E79B-0BBD-4E2A-9122-2CD42B74B06B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DotNet.DocsTools", "..\..\DotNet.DocsTools\DotNet.DocsTools.csproj", "{1BDD7A74-45B3-47C7-B605-DFC9B82D87AF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -38,6 +40,10 @@ Global
 		{02A9E79B-0BBD-4E2A-9122-2CD42B74B06B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{02A9E79B-0BBD-4E2A-9122-2CD42B74B06B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{02A9E79B-0BBD-4E2A-9122-2CD42B74B06B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1BDD7A74-45B3-47C7-B605-DFC9B82D87AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1BDD7A74-45B3-47C7-B605-DFC9B82D87AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1BDD7A74-45B3-47C7-B605-DFC9B82D87AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1BDD7A74-45B3-47C7-B605-DFC9B82D87AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -249,7 +249,7 @@ public class GithubIssue
             // This feels like a hack, but it is necessary.
             // The email address is the email address a person configured
             // However, the only guaranteed way to find the person in Quest 
-            // is to use their alais as an email address. Yuck.
+            // is to use their alias as an email address. Yuck.
             if (identity?.MicrosoftInfo?.EmailAddress?.EndsWith("@microsoft.com") == true)
                 return identity.MicrosoftInfo.Alias + "@microsoft.com";
             else


### PR DESCRIPTION
Fixes #116
Fixes dotnet/docs#33826

There are two important logic changes here. Both are in the PageGenerationService class.

- When a major change is detected, search the configured heading areas in text order to find the first match. That's the area where this change should be located. Add the header to the data record for changes in this file.
- Rework the LINQ query to retrieve the changes by matched header. Because the section header was found earlier, this is a simpler query.