### PR TITLE
Dont stress opso service

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/Actor.cs
+++ b/DotNet.DocsTools/GitHubObjects/Actor.cs
@@ -64,6 +64,7 @@ public readonly struct Actor
         // Note that for "ghost", the gitHubLogin is null or empty here.
         try
         {
+            // TODO: This is always called from command line apps. Use the full cache.
             var info = await ospoClient.GetAsync(Login);
             bool? rVal = null;
             if ((info is null) || (info.MicrosoftInfo is null))

--- a/DotNet.DocsTools/OspoClientServices/OspoClient.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClient.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotnetOrg.Ospo;
 public sealed class OspoClient : IDisposable
 {
     private readonly HttpClient _httpClient;
+    private OspoLinkSet? _allLinks = default;
     private readonly Dictionary<string, OspoLink?> _allEmployeeQueries = new();
     private readonly AsyncRetryPolicy _retryPolicy;
 
@@ -62,6 +63,8 @@ public sealed class OspoClient : IDisposable
     
     public async Task<OspoLinkSet> GetAllAsync()
     {
+        if (_allLinks is not null)
+            return _allLinks;
         var result = await _retryPolicy.ExecuteAndCaptureAsync(async () =>
         {
             var links = await _httpClient.GetFromJsonAsync<IReadOnlyList<OspoLink>>(
@@ -75,7 +78,7 @@ public sealed class OspoClient : IDisposable
             linkSet.Initialize();
             return linkSet;
         });
-
+        _allLinks = result.Result;
         return result.Result;
     }
 }

--- a/DotNet.DocsTools/OspoClientServices/OspoClient.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClient.cs
@@ -32,7 +32,7 @@ public sealed class OspoClient : IDisposable
         _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("basic", Convert.ToBase64String(Encoding.ASCII.GetBytes($":{token}")));
 
         var delay = Backoff.DecorrelatedJitterBackoffV2(
-            medianFirstRetryDelay: TimeSpan.FromSeconds(15), retryCount: 5);
+            medianFirstRetryDelay: TimeSpan.FromMinutes(3), retryCount: 2);
 
         _retryPolicy = Policy
             .Handle<HttpRequestException>(ex =>

--- a/IssueCloser/Program.cs
+++ b/IssueCloser/Program.cs
@@ -42,7 +42,7 @@ That automated process may have closed some issues that should be addressed. If 
         "");
 
         var client = IGitHubClient.CreateGitHubClient(key);
-        var ospoClient = new OspoClient(ospoKey);
+        var ospoClient = new OspoClient(ospoKey, true);
         var labelQuery = new FindLabelQuery(client, organization, repository, "won't fix");
         if (!(await labelQuery.PerformQuery()))
         {

--- a/WhatsNew.Infrastructure/Services/ConfigurationService.cs
+++ b/WhatsNew.Infrastructure/Services/ConfigurationService.cs
@@ -43,7 +43,7 @@ public class ConfigurationService
 
         var client = IGitHubClient.CreateGitHubClient(key);
 
-        var ospoClient = new OspoClient(ospoKey);
+        var ospoClient = new OspoClient(ospoKey, true);
         
         if (string.IsNullOrWhiteSpace(input.Branch))
         {

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -228,17 +228,6 @@ public class GithubIssue
     /// Retrieve the assigned name, if an MS employee
     /// </summary>
     /// <param name="ospoClient">The Open Source program office client service.</param>
-    /// <returns>The email address of the assignee</returns>
-    public async Task<string?> AuthorMicrosoftEmailAddress(OspoClient ospoClient)
-    {
-        var identity = await ospoClient.GetAsync(Author);
-        return identity?.MicrosoftInfo?.EmailAddress;
-    }
-
-    /// <summary>
-    /// Retrieve the assigned name, if an MS employee
-    /// </summary>
-    /// <param name="ospoClient">The Open Source program office client service.</param>
     /// <returns>The email address of the assignee. Null if unassigned, or the assignee is not a 
     /// Microsoft FTE.</returns>
     public async Task<string?> AssignedMicrosoftEmailAddress(OspoClient ospoClient)

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -44,7 +44,7 @@ public class QuestGitHubService : IDisposable
         string importedLabel)
     {
         _ghClient = IGitHubClient.CreateGitHubClient(ghKey);
-        _ospoClient = new OspoClient(ospoKey);
+        _ospoClient = new OspoClient(ospoKey, false);
         _azdoClient = new QuestClient(azdoKey, questOrg, questProject);
         _areaPath = areaPath;
         _questLinkString = $"https://dev.azure.com/{questOrg}/{questProject}/_workitems/edit/";


### PR DESCRIPTION
In order to recognize community contributors, our tools often use the OSPO REST service to attempt to match a GitHub login to an MS email or alias. This service isn't designed for broad use, and we would get rate limited by repeated API calls.

The What's New tool caused the most problems. Happily, we have many community members that contribute to our docs. The tool would call the REST service for each PR. 

In this PR, those tools that will make multiple REST calls now make a single call to retrieve the entire list of MS employees with registered GitHub aliases. That list is only stored in memory while the app runs. Then, each call to determine if a GitHub alias matches an employee uses that in memory cache. 

Other tools (seQuester) still make the call for a single ID. Those tools operate on a single issue, and that packet is smaller.
