### PR TITLE
Fix an error with snippets 5000 in CI builds

### DIFF
--- a/DotNet.DocsTools/GraphQLQueries/FilesInPullRequest.cs
+++ b/DotNet.DocsTools/GraphQLQueries/FilesInPullRequest.cs
@@ -90,7 +90,7 @@ public class FilesInPullRequest
             }
 
             var filesNode = jsonData.Descendent("repository", "pullRequest", "files");
-                (hasMore, cursor) = filesNode.NextPageInfo();
+            (hasMore, cursor) = filesNode.NextPageInfo();
 
 
             var elements = filesNode.GetProperty("nodes").EnumerateArray();


### PR DESCRIPTION
The CI builds in the API docs project produce PRs that may contain thousands of files.

When the PR contains that many files, the query to retrieve the paths of all the files in the PR throws an invalid operation exception.

Ignore it and return an empty sequence of files.