### PR TITLE
Better switch handling for CleanRepo tool

### DIFF
--- a/cleanrepo/CleanRepo/Dockerfile
+++ b/cleanrepo/CleanRepo/Dockerfile
@@ -7,4 +7,4 @@ RUN dotnet publish "CleanRepo.csproj" -c Release -o out --no-self-contained
 # Relayer the .NET SDK, anew with the build output
 FROM mcr.microsoft.com/dotnet/sdk:7.0
 COPY --from=build-env /app/out .
-ENTRYPOINT [ "dotnet", "/CleanRepo.dll" ]
+ENTRYPOINT [ "/bin/sh", "/multiplexer.sh" ]

--- a/cleanrepo/CleanRepo/Program.cs
+++ b/cleanrepo/CleanRepo/Program.cs
@@ -24,10 +24,22 @@ class Program
     static void Main(string[] args)
     {
 #if DEBUG
+        // TODO: Consider using launchSettings.json with command line args instead:
+        //
+        //   {
+        //     "profiles": {
+        //       "CleanRepo": {
+        //         "commandName": "Project",
+        //         "commandLineArgs": "--orphaned-images\r\n--base-path=\"/dotnet\""
+        //       }
+        //     }
+        //   }
+        //
+        // ... to void hardcoded values in DEBUG preprocessor directives like this:
         //args = new[] { "--trim-redirects", "--docset-root=c:\\users\\gewarren\\dotnet-docs\\docs", "--lookback-days=90", "--output-file=c:\\users\\gewarren\\desktop\\clicks.txt" };
         //args = new[] { "--remove-hops" };
         //args = new[] { "--replace-redirects" };
-        args = new[] { "--orphaned-images", "--base-path=/dotnet" };
+        //args = new[] { "--orphaned-images", "--base-path=/dotnet" };
 #endif
 
         Parser.Default.ParseArguments<Options>(args).WithParsed(RunOptions);
@@ -75,8 +87,9 @@ class Program
 
             ListOrphanedTopics(tocFiles, markdownFiles, options.Delete.Value);
         }
+
         // Find orphaned images
-        else if (options.FindOrphanedImages)
+        if (options.FindOrphanedImages)
         {
             // Get input directory.
             if (String.IsNullOrEmpty(options.InputDirectory))
@@ -131,7 +144,9 @@ class Program
 
             repo.ListOrphanedImages(options.Delete.Value, "snippets");
         }
-        else if (options.CatalogImages)
+
+        // Catalog images
+        if (options.CatalogImages)
         {
             // Get input directory.
             if (String.IsNullOrEmpty(options.InputDirectory))
@@ -175,8 +190,9 @@ class Program
 
             repo.OutputImageReferences();
         }
+
         // Find orphaned include-type files
-        else if (options.FindOrphanedIncludes)
+        if (options.FindOrphanedIncludes)
         {
             if (String.IsNullOrEmpty(options.InputDirectory))
             {
@@ -213,8 +229,9 @@ class Program
 
             ListOrphanedIncludes(options.InputDirectory, includeFiles, options.Delete.Value);
         }
+
         // Find orphaned .cs and .vb files
-        else if (options.FindOrphanedSnippets)
+        if (options.FindOrphanedSnippets)
         {
             if (String.IsNullOrEmpty(options.InputDirectory))
             {
@@ -250,8 +267,9 @@ class Program
 
             ListOrphanedSnippets(options.InputDirectory, snippetFiles, options.Delete.Value);
         }
+
         // Replace links to topics that are redirected in the master redirection file.
-        else if (options.ReplaceRedirectTargets)
+        if (options.ReplaceRedirectTargets)
         {
             // Get the directory in which to replace links.
             if (String.IsNullOrEmpty(options.InputDirectory))
@@ -325,8 +343,9 @@ class Program
 
             Console.WriteLine("\nFinished replacing links.");
         }
+
         // Replace site-relative links to *this* repo with file-relative links.
-        else if (options.ReplaceWithRelativeLinks)
+        if (options.ReplaceWithRelativeLinks)
         {
             if (String.IsNullOrEmpty(options.InputDirectory))
             {
@@ -394,8 +413,9 @@ class Program
             // Check all links in these files.
             ReplaceLinks(linkingFiles, urlBasePath, rootDirectory);
         }
-        // Remove hops/daisy chains in a redirection file.
-        else if (options.RemoveRedirectHops)
+
+        // Remove hops/daisy chains in a redirection file.        
+        if (options.RemoveRedirectHops)
         {
             // Get the directory that represents the docset.
             if (String.IsNullOrEmpty(options.InputDirectory))
@@ -452,8 +472,16 @@ class Program
                 RemoveRedirectHops(redirectsFile, docsets, opsConfigFile.DirectoryName);
             }
         }
+
         // Nothing to do.
-        else
+        if (options.FindOrphanedTopics is false &&
+            options.FindOrphanedImages is false &&
+            options.CatalogImages is false &&
+            options.FindOrphanedIncludes is false &&
+            options.FindOrphanedSnippets is false &&
+            options.ReplaceRedirectTargets is false &&
+            options.ReplaceWithRelativeLinks is false &&
+            options.RemoveRedirectHops is false)
         {
             Console.WriteLine("\nYou did not specify which function to perform. To see options, use 'CleanRepo.exe -?'.");
             return;

--- a/cleanrepo/CleanRepo/action.yml
+++ b/cleanrepo/CleanRepo/action.yml
@@ -6,45 +6,45 @@ branding:
   icon: 'sliders'
   color: 'purple'
 inputs:
-  start-directory:
+  start_directory:
     description: 'Top-level directory in which to perform clean up (for example, find orphaned markdown files).'
     required: true
-  docset-root:
+  docset_root:
     description: 'The full path to the root directory for the docset, e.g. "./dotnet-docs/docs".'
     default: './docs'
-  repo-root:
+  repo_root:
     description: 'The full path to the local root directory for the repository, e.g. "dotnet-docs"'
     default: '.'
   delete:
     description: 'True to delete orphaned files.'
     default: 'false'
-  orphaned-topics:
+  orphaned_topics:
     description: 'Use this option to find orphaned topics.'
     default: 'false'
-  orphaned-images:
+  orphaned_images:
     description: 'Find orphaned .png, .gif, .jpg, or .svg files.'
     default: 'false'
-  catalog-images:
+  catalog_images:
     description: 'Map images to the markdown/YAML files that reference them.'
     default: 'false'
-  orphaned-snippets:
+  orphaned_snippets:
     description: 'Find orphaned .cs and .vb files.'
     default: 'false'
-  orphaned-includes:
+  orphaned_includes:
     description: 'Find orphaned INCLUDE files.'
     default: 'false'
-  lookback-days:
+  lookback_days:
     description: 'The number of days to check for link-click activity.'
     default: '180'
-  output-file:
+  output_file:
     description: 'The file to write the redirect page view output to.'
-  replace-redirects:
+  replace_redirects:
     description: 'Find backlinks to redirected files and replace with new target.'
     default: 'false'
-  relative-links:
+  relative_links:
     description: 'Replace site-relative links with file-relative links.'
     default: 'false'
-  remove-hops:
+  remove_hops:
     description: 'Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).'
     default: 'false'
 runs:
@@ -52,30 +52,30 @@ runs:
   image: Dockerfile
   args:
     - '--start-directory'
-    - ${{ inputs.start-directory }}
+    - ${{ inputs.start_directory }}
     - '--docset-root'
-    - ${{ inputs.docset-root }}
+    - ${{ inputs.docset_root }}
     - '--repo-root'
-    - ${{ inputs.repo-root }}
+    - ${{ inputs.repo_root }}
     - '--delete'
     - ${{ inputs.delete }}
     - '--orphaned-topics'
-    - ${{ inputs.orphaned-topics }}
+    - ${{ inputs.orphaned_topics }}
     - '--orphaned-images'
-    - ${{ inputs.orphaned-images }}
+    - ${{ inputs.orphaned_images }}
     - '--catalog-images'
-    - ${{ inputs.catalog-images }}
+    - ${{ inputs.catalog_images }}
     - '--orphaned-snippets'
-    - ${{ inputs.orphaned-snippets }} 
+    - ${{ inputs.orphaned_snippets }} 
     - '--orphaned-includes'
-    - ${{ inputs.orphaned-includes }}
+    - ${{ inputs.orphaned_includes }}
     - '--lookback-days'
-    - ${{ inputs.lookback-days }}
+    - ${{ inputs.lookback_days }}
     - '--output-file'
-    - ${{ inputs.output-file }}
+    - ${{ inputs.output_file }}
     - '--replace-redirects'
-    - ${{ inputs.replace-redirects }}
+    - ${{ inputs.replace_redirects }}
     - '--relative-links'
-    - ${{ inputs.relative-links }}
+    - ${{ inputs.relative_links }}
     - '--remove-hops'
-    - ${{ inputs.remove-hops }}
+    - ${{ inputs.remove_hops }}

--- a/cleanrepo/CleanRepo/multiplexer.sh
+++ b/cleanrepo/CleanRepo/multiplexer.sh
@@ -38,7 +38,7 @@ fi
 
 # Find orphaned .png, .gif, .jpg, or .svg files.
 if env_var_is_set "INPUT_ORPHANED-IMAGES"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \
@@ -48,7 +48,7 @@ fi
 
 # Find orphaned .cs and .vb files.
 if env_var_is_set "INPUT_ORPHANED-SNIPPETS"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \
@@ -58,7 +58,7 @@ fi
 
 # Find orphaned INCLUDE files.
 if env_var_is_set "INPUT_ORPHANED-INCLUDES"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \
@@ -68,7 +68,7 @@ fi
 
 # Find backlinks to redirected files and replace with new target.
 if env_var_is_set "INPUT_REPLACE-REDIRECTS"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \
@@ -78,7 +78,7 @@ fi
 
 # Replace site-relative links with file-relative links.
 if env_var_is_set "INPUT_RELATIVE-LINKS"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \
@@ -88,7 +88,7 @@ fi
 
 # Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
 if env_var_is_set "INPUT_REMOVE-HOPS"; then
-	dotnet CleanRepo.dll  -- \
+	dotnet CleanRepo.dll -- \
 	--start-directory="$STARTING_DIR" \
 	--docset-root="$DOCSET_ROOT" \
 	--repo-root="$REPO_ROOT" \

--- a/cleanrepo/CleanRepo/multiplexer.sh
+++ b/cleanrepo/CleanRepo/multiplexer.sh
@@ -10,13 +10,13 @@ set -eu -o pipefail
 #
 # Optional environment variables:
 #
-#   INPUT_ORPHANED-TOPICS (--orphaned-topics): Use this option to find orphaned topics.
-#   INPUT_ORPHANED-IMAGES (--orphaned-images): Find orphaned .png, .gif, .jpg, or .svg files.
-#   INPUT_ORPHANED-SNIPPETS (--orphaned-snippets): Find orphaned .cs and .vb files.
-#   INPUT_ORPHANED-INCLUDES (--orphaned-includes): Find orphaned INCLUDE files.
-#   INPUT_REPLACE-REDIRECTS (--replace-redirects): Find backlinks to redirected files and replace with new target.
-#   INPUT_RELATIVE-LINKS (--relative-links): Replace site-relative links with file-relative links.
-#   INPUT_REMOVE-HOPS (--remove-hops): Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
+#   INPUT_ORPHANED_TOPICS (--orphaned-topics): Use this option to find orphaned topics.
+#   INPUT_ORPHANED_IMAGES (--orphaned-images): Find orphaned .png, .gif, .jpg, or .svg files.
+#   INPUT_ORPHANED_SNIPPETS (--orphaned-snippets): Find orphaned .cs and .vb files.
+#   INPUT_ORPHANED_INCLUDES (--orphaned-includes): Find orphaned INCLUDE files.
+#   INPUT_REPLACE_REDIRECTS (--replace-redirects): Find backlinks to redirected files and replace with new target.
+#   INPUT_RELATIVE_LINKS (--relative-links): Replace site-relative links with file-relative links.
+#   INPUT_REMOVE_HOPS (--remove-hops): Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
 
 env_var_is_set() {
 	if [[ "${!1}" =~ ^[Tt]rue$|^[1]$ ]]; then
@@ -27,71 +27,71 @@ env_var_is_set() {
 }
 
 # Use this option to find orphaned topics.
-if env_var_is_set "INPUT_ORPHANED-TOPICS"; then
+if env_var_is_set "INPUT_ORPHANED_TOPICS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--delete --orphaned-topics
 fi
 
 # Find orphaned .png, .gif, .jpg, or .svg files.
-if env_var_is_set "INPUT_ORPHANED-IMAGES"; then
+if env_var_is_set "INPUT_ORPHANED_IMAGES"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--delete --orphaned-images
 fi
 
 # Find orphaned .cs and .vb files.
-if env_var_is_set "INPUT_ORPHANED-SNIPPETS"; then
+if env_var_is_set "INPUT_ORPHANED_SNIPPETS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--delete --orphaned-snippets
 fi
 
 # Find orphaned INCLUDE files.
-if env_var_is_set "INPUT_ORPHANED-INCLUDES"; then
+if env_var_is_set "INPUT_ORPHANED_INCLUDES"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--delete --orphaned-includes
 fi
 
 # Find backlinks to redirected files and replace with new target.
-if env_var_is_set "INPUT_REPLACE-REDIRECTS"; then
+if env_var_is_set "INPUT_REPLACE_REDIRECTS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--replace-redirects
 fi
 
 # Replace site-relative links with file-relative links.
-if env_var_is_set "INPUT_RELATIVE-LINKS"; then
+if env_var_is_set "INPUT_RELATIVE_LINKS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory="$INPUT_STARTING_DIR" \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--relative-links
 fi
 
 # Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
-if env_var_is_set "INPUT_REMOVE-HOPS"; then
+if env_var_is_set "INPUT_REMOVE_HOPS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory="$STARTING_DIR" \
-	--docset-root="$DOCSET_ROOT" \
-	--repo-root="$REPO_ROOT" \
-	--base-path="$BASE_PATH" \
+	--start-directory='$INPUT_STARTING-DIRECTORY' \
+	--docset-root='$INPUT_DOCSET-ROOT' \
+	--repo-root='$INPUT_REPO-ROOT' \
+	--base-path='$INPUT_BASE-PATH' \
 	--remove-hops
 fi

--- a/cleanrepo/CleanRepo/multiplexer.sh
+++ b/cleanrepo/CleanRepo/multiplexer.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -eu -o pipefail
+
+# Requires the following environment variables:
+#
+#   INPUT_STARTING-DIR (--start-directory): Top-level directory in which to perform clean up (for example, find orphaned markdown files).
+#   INPUT_DOCSET-ROOT (--docset-root): The full path to the root directory for the docset, e.g. 'c:\\users\\gewarren\\dotnet-docs\\docs'.
+#   INPUT_REPO-ROOT (--repo-root): The full path to the local root directory for the repository, e.g. 'c:\\users\\gewarren\\dotnet-docs'.
+#   INPUT_BASE-PATH (--base-path): The URL base path for the docset, e.g. '/windows/uwp' or '/dotnet'.
+#
+# Optional environment variables:
+#
+#   INPUT_ORPHANED-TOPICS (--orphaned-topics): Use this option to find orphaned topics.
+#   INPUT_ORPHANED-IMAGES (--orphaned-images): Find orphaned .png, .gif, .jpg, or .svg files.
+#   INPUT_ORPHANED-SNIPPETS (--orphaned-snippets): Find orphaned .cs and .vb files.
+#   INPUT_ORPHANED-INCLUDES (--orphaned-includes): Find orphaned INCLUDE files.
+#   INPUT_REPLACE-REDIRECTS (--replace-redirects): Find backlinks to redirected files and replace with new target.
+#   INPUT_RELATIVE-LINKS (--relative-links): Replace site-relative links with file-relative links.
+#   INPUT_REMOVE-HOPS (--remove-hops): Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
+
+env_var_is_set() {
+	if [[ "${!1}" =~ ^[Tt]rue$|^[1]$ ]]; then
+		return 0
+	else
+		return 1
+  fi
+}
+
+# Use this option to find orphaned topics.
+if env_var_is_set "INPUT_ORPHANED-TOPICS"; then
+	dotnet CleanRepo.dll -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--delete --orphaned-topics
+fi
+
+# Find orphaned .png, .gif, .jpg, or .svg files.
+if env_var_is_set "INPUT_ORPHANED-IMAGES"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--delete --orphaned-images
+fi
+
+# Find orphaned .cs and .vb files.
+if env_var_is_set "INPUT_ORPHANED-SNIPPETS"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--delete --orphaned-snippets
+fi
+
+# Find orphaned INCLUDE files.
+if env_var_is_set "INPUT_ORPHANED-INCLUDES"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--delete --orphaned-includes
+fi
+
+# Find backlinks to redirected files and replace with new target.
+if env_var_is_set "INPUT_REPLACE-REDIRECTS"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--replace-redirects
+fi
+
+# Replace site-relative links with file-relative links.
+if env_var_is_set "INPUT_RELATIVE-LINKS"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--relative-links
+fi
+
+# Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
+if env_var_is_set "INPUT_REMOVE-HOPS"; then
+	dotnet CleanRepo.dll  -- \
+	--start-directory="$STARTING_DIR" \
+	--docset-root="$DOCSET_ROOT" \
+	--repo-root="$REPO_ROOT" \
+	--base-path="$BASE_PATH" \
+	--remove-hops
+fi

--- a/cleanrepo/CleanRepo/multiplexer.sh
+++ b/cleanrepo/CleanRepo/multiplexer.sh
@@ -4,9 +4,9 @@ set -eu -o pipefail
 # Requires the following environment variables:
 #
 #   INPUT_STARTING-DIR (--start-directory): Top-level directory in which to perform clean up (for example, find orphaned markdown files).
-#   INPUT_DOCSET-ROOT (--docset-root): The full path to the root directory for the docset, e.g. 'c:\\users\\gewarren\\dotnet-docs\\docs'.
-#   INPUT_REPO-ROOT (--repo-root): The full path to the local root directory for the repository, e.g. 'c:\\users\\gewarren\\dotnet-docs'.
-#   INPUT_BASE-PATH (--base-path): The URL base path for the docset, e.g. '/windows/uwp' or '/dotnet'.
+#   INPUT_DOCSET_ROOT (--docset-root): The full path to the root directory for the docset, e.g. "c:\\users\\gewarren\\dotnet-docs\\docs".
+#   INPUT_REPO_ROOT (--repo-root): The full path to the local root directory for the repository, e.g. "c:\\users\\gewarren\\dotnet-docs".
+#   INPUT_BASE_PATH (--base-path): The URL base path for the docset, e.g. "/windows/uwp" or "/dotnet".
 #
 # Optional environment variables:
 #
@@ -29,50 +29,50 @@ env_var_is_set() {
 # Use this option to find orphaned topics.
 if env_var_is_set "INPUT_ORPHANED_TOPICS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--delete --orphaned-topics
 fi
 
 # Find orphaned .png, .gif, .jpg, or .svg files.
 if env_var_is_set "INPUT_ORPHANED_IMAGES"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--delete --orphaned-images
 fi
 
 # Find orphaned .cs and .vb files.
 if env_var_is_set "INPUT_ORPHANED_SNIPPETS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--delete --orphaned-snippets
 fi
 
 # Find orphaned INCLUDE files.
 if env_var_is_set "INPUT_ORPHANED_INCLUDES"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--delete --orphaned-includes
 fi
 
 # Find backlinks to redirected files and replace with new target.
 if env_var_is_set "INPUT_REPLACE_REDIRECTS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--replace-redirects
 fi
 
@@ -80,18 +80,18 @@ fi
 if env_var_is_set "INPUT_RELATIVE_LINKS"; then
 	dotnet CleanRepo.dll -- \
 	--start-directory="$INPUT_STARTING_DIR" \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--relative-links
 fi
 
 # Clean redirection JSON file by replacing targets that are themselves redirected (daisy chains).
 if env_var_is_set "INPUT_REMOVE_HOPS"; then
 	dotnet CleanRepo.dll -- \
-	--start-directory='$INPUT_STARTING-DIRECTORY' \
-	--docset-root='$INPUT_DOCSET-ROOT' \
-	--repo-root='$INPUT_REPO-ROOT' \
-	--base-path='$INPUT_BASE-PATH' \
+	--start-directory="$INPUT_STARTING_DIRECTORY" \
+	--docset-root="$INPUT_DOCSET_ROOT" \
+	--repo-root="$INPUT_REPO_ROOT" \
+	--base-path="$INPUT_BASE_PATH" \
 	--remove-hops
 fi


### PR DESCRIPTION
## Background

I can call a bash script from the _Dockerfile_, however, I cannot access the command line args given to the docker run command, from within the _Dockferfile_ itself. In looking at the clean repo tool exe, I'm proposing that we change the `if / else if / else` in the `RunOptions` with standalone `if` statements. This means, you can give your tool all the options you want it to perform, and it will do all of them in sequence. I believe that this is a non-breaking change, but at least allows us the flexibility to call the tool once if we eventually desire that.

**TL;DR;**

The problem is that as a GitHub Action, in order to get the arguments passed to it from a consuming workflow, we must use the existing GitHub Action infrastructure. It passes their arguments as command line args to the `docker run` command, as shown here in this example (an example Action run from the quest importer which uses the same docker GHA model):

```shell
/usr/bin/docker run --name ccc55a73283a34d22a3445df6d27b1f47_b30ba5 
  --label 49859c --workdir /github/workspace 
  --rm -e "ImportOptions__ApiKeys__GitHubToken" 
  -e "ImportOptions__ApiKeys__OSPOKey" 
  -e "ImportOptions__ApiKeys__QuestKey" 
  -e "INPUT_ORG" -e "INPUT_REPO" -e "INPUT_ISSUE" 
  -e "INPUT_BRANCH" -e "HOME" -e "GITHUB_JOB" 
  -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" 
  -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" 
  -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" 
  -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" 
  -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" 
  -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" 
  -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" 
  -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" 
  -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" 
  -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" 
  -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" 
  -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" 
  -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" 
  -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" 
  -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" 
  -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_TOOL_CACHE" 
  -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" 
  -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" 
  -e GITHUB_ACTIONS=true -e CI=true 
  -v "/var/run/docker.sock":"/var/run/docker.sock" 
  -v "/home/runner/work/_temp/_github_home":"/github/home" 
  -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" 
  -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" 
  -v "/home/runner/work/docs/docs":"/github/workspace" 
  49859c:cc55a73283a34d22a3445df6d27b1f47  
  "--org" "dotnet" 
  "--repo" "dotnet/docs" 
  "--issue" "33362" 
  "--branch" "main"
```

The _Dockerfile_ itself cannot access the trailing command line args, as such, we cannot evaluate any of the options the workflow has expressed. This means that when our bash script tries to call dotnet _CleanRepo.dll_ it wouldn't know what switches to pass. As an alternative approach, I'm proposing that we try accessing the input environment variables directly.

## In this PR

1. Update _Dockerfile_ entrypoint, `ENTRYPOINT [ "/bin/sh", "/multiplexer.sh" ]`.
1. Added TODO comment about hardcoded `#if DEBUG` overriding `args`.
1. Converted the _Program.cs_ to use standalone if statements, enabling multiple switches.
1. Add _multiplexer.sh_ bash script to run the _CleanRepo.dll_ for any available switch.

> **Note**
> The naming convention for inputs in env vars is `INPUT_<INPUT-NAME>`, for more information, see [GitHub Action Workflow: Metadata syntax - Inputs](https://docs.github.com/actions/creating-actions/metadata-syntax-for-github-actions#inputs).

I think this should work, but we'll have to test it. If the bash script approach doesn't work, we should be able to easily remove the script altogether, and just call `ENTRYPOINT [ "dotnet", "/CleanRepo.dll" ]` with no other changes - assuming the _Program.cs_ changes remain in place.

Related to https://github.com/dotnet/docs/pull/34257#discussion_r1120705902