### PR TITLE
Handle missing data in graphs and tables

### DIFF
--- a/GitHub.RepositoryExplorer.Client/Extensions/LocalStorageServiceExtensions.cs
+++ b/GitHub.RepositoryExplorer.Client/Extensions/LocalStorageServiceExtensions.cs
@@ -22,4 +22,5 @@ internal static class LocalStorageServiceExtensions
         }
         catch { }
     }
+
 }

--- a/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
+++ b/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>1e8b5bf8-1a2d-446d-9cd3-48609334c53f</UserSecretsId>
-    <AssemblyVersion>1.0.1.0</AssemblyVersion>
-    <FileVersion>1.0.1.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitHub.RepositoryExplorer.Client/Pages/Areas.razor
+++ b/GitHub.RepositoryExplorer.Client/Pages/Areas.razor
@@ -67,7 +67,7 @@
                                                         @onclick=@(() => PrepareModalData(product, null, priority))
                                                         @onclick:preventDefault="true"
                                                         @onclick:stopPropagation="true">
-                                                        @($"{priority.DisplayLabel}: {GetIssueCountForProductAndPriority(product.Label, priority.Label):#,0}")
+                                                        @($"{priority.DisplayLabel}: {GetIssueCountForProductAndPriority(product.Label, priority.Label)}")
                                                     </span>
                                                 </span>
                                         }
@@ -126,7 +126,7 @@
                                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                                 </div>
                                 <div class="modal-body">
-                                    @foreach (var (index, title, count) in _modalData.Select((item, index) => (index, item.Title, item.Count)))
+                                    @foreach (var (index, title, count) in _modalData.Select((item, index) => (index, item.Title, item.Count == -1 ? "?" : item.Count.ToString())))
                                 {
                                     var isLastRow = _modalData.Count == index + 1;
                                     var style = isLastRow ? "fw-bold" : "";

--- a/GitHub.RepositoryExplorer.Client/Pages/Areas.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/Areas.razor.cs
@@ -69,7 +69,7 @@ public sealed partial class Areas
                 };
                 StateHasChanged();
 
-                var data = await IssuesClient.GetIssuesForDateAsync(state, date);
+                var data = await IssuesClient.GetIssuesForDateAsync(state, date, classifications);
                 if (data is { Issues.Length: > 0 })
                 {
                     _summaryState = _summaryState with
@@ -114,11 +114,17 @@ public sealed partial class Areas
         return Task.CompletedTask;
     }
 
-    public int GetIssueCountForProductAndPriority(
-        string productLabel, string priorityLabel) =>
-         _summaryState.Data.IssueCount(productLabel, null, priorityLabel, null);
+    public string GetIssueCountForProductAndPriority(
+        string productLabel, string priorityLabel)
+    {
+        var count = _summaryState.Data.IssueCount(productLabel, null, priorityLabel, null);
+        return count == -1 ? "?" : $"{count:#,0}";
+    }
 
-    public int GetIssueCountForProductTechAndPriority(
-        string productLabel, string techLabel, string priorityLabel) =>
-        _summaryState.Data.IssueCount(productLabel, techLabel, priorityLabel, null);
+    public string GetIssueCountForProductTechAndPriority(
+        string productLabel, string techLabel, string priorityLabel)
+    {
+        int count = _summaryState.Data.IssueCount(productLabel, techLabel, priorityLabel, null);
+        return count == -1 ? "?" : $"{count}";
+    }
 }

--- a/GitHub.RepositoryExplorer.Client/Pages/ClassificationLineChart.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/ClassificationLineChart.razor.cs
@@ -133,9 +133,12 @@ public partial class ClassificationLineChart: ComponentBase
                     foreach (var grouping in _issueSnapshots)
                     {
                         var color = ColorUtil.RandomColorString();
+                        double[] lineSeries = grouping.DailyCount
+                            .Select(i => (i == -1) ? double.NaN : (double)i)
+                            .ToArray();
                         _chartConfig.Data.Datasets.Add(
-                            new LineDataset<int>(
-                                grouping.DailyCount)
+                            new LineDataset<double>(
+                                lineSeries)
                             {
                                 Fill = FillingMode.Start,
                                 Label = classifications.ClassificationWithUnassigned().First(p => p.Label == grouping.Classification).DisplayLabel,

--- a/GitHub.RepositoryExplorer.Client/Pages/ProductLineChartJS.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/ProductLineChartJS.razor.cs
@@ -132,10 +132,12 @@ public partial class ProductLineChartJS : ComponentBase
                     foreach (var grouping in _issueSnapshots)
                     {
                         var color = ColorUtil.RandomColorString();
-
+                        double[] lineSeries = grouping.DailyCount
+                            .Select(i => (i == -1) ? double.NaN : (double)i)
+                            .ToArray();
                         _chartConfig.Data.Datasets.Add(
-                            new LineDataset<int>(
-                                grouping.DailyCount)
+                            new LineDataset<double>(
+                                lineSeries)
                             {
                                 Fill = FillingMode.Start,
                                 Label = classifications.ProductWithUnassigned().First(p => p.Label == grouping.Product).DisplayLabel,

--- a/GitHub.RepositoryExplorer.Client/Pages/SummaryChartJS.razor.cs
+++ b/GitHub.RepositoryExplorer.Client/Pages/SummaryChartJS.razor.cs
@@ -86,7 +86,7 @@ public sealed partial class SummaryChartJS
                 };
                 StateHasChanged();
 
-                var data = await IssuesClient.GetIssuesForDateAsync(state, _date);
+                var data = await IssuesClient.GetIssuesForDateAsync(state, _date, classifications);
                 if (classifications is not null && data is { Issues.Length: > 0 })
                 {
                     _summaryState = _summaryState with
@@ -109,9 +109,9 @@ public sealed partial class SummaryChartJS
                     // data is the DailyRecord.
                     foreach (var priority in _repoLabelsState.IssueClassification.PriorityWithUnassigned())
                     {
-                        IDataset<int> dataset = new BarDataset<int>(classifications
+                        IDataset<double> dataset = new BarDataset<double>(classifications
                             .Products
-                            .Select(p => data.Issues.IssueCount(p.Label, null, priority.Label, null)))
+                            .Select(p => data.Issues.IssueCount(p.Label, null, priority.Label, null) == -1 ? double.NaN : data.Issues.IssueCount(p.Label, null, priority.Label, null)))
                         {
                             Label = priority.DisplayLabel,
                             BackgroundColor = PriorityColor(priority.Label)

--- a/GitHub.RepositoryExplorer.Client/Services/DailyRecordFactory.cs
+++ b/GitHub.RepositoryExplorer.Client/Services/DailyRecordFactory.cs
@@ -1,0 +1,46 @@
+﻿namespace GitHub.RepositoryExplorer.Client.Services
+{
+    public static class DailyRecordFactory
+    {
+        internal static DailyRecord CreateMissingRecord(DateOnly date, IssueClassificationModel model, string? org, string? repo)
+        {
+
+            var productIssueCounts = new List<ProductIssueCount>();
+            foreach (var prod in model.Products.
+                Append(new Product { Label = "*", DisplayLabel = "Unnassigned", Technologies = Array.Empty<Technology>() }).
+                Append(new Product { Label = null!, DisplayLabel = "Total", Technologies = Array.Empty<Technology>() }))
+            {
+                var technologyIssueCounts = new List<TechnologyIssueCount>();
+                foreach (var tech in prod.Technologies
+                    .Append(new Technology { Label = null!, DisplayLabel = "Total" }))
+                {
+                    var priorityIssueCounts = new List<PriorityIssueCount>();
+                    foreach (var priority in model.Priorities
+                        .Append(new Priority { Label = "*", DisplayLabel = "Unassigned" })
+                        .Append(new Priority { Label = null!, DisplayLabel = "Total" }))
+                    {
+                        var classificationIssueCounts = new List<ClassificationIssueCount>();
+                        foreach (var classification in model.Classification
+                        .Append(new Classification { Label = "*", DisplayLabel = "Unassigned" })
+                        .Append(new Classification { Label = null!, DisplayLabel = "Total" }))
+                        {
+                            var issueCount = -1;
+                            classificationIssueCounts.Add(new ClassificationIssueCount(classification.Label, issueCount));
+                        }
+                        priorityIssueCounts.Add(new PriorityIssueCount(priority.Label, classificationIssueCounts.ToArray()));
+                    }
+                    technologyIssueCounts.Add(new TechnologyIssueCount(tech.Label, priorityIssueCounts.ToArray()));
+                }
+                productIssueCounts.Add(new ProductIssueCount(prod.Label, technologyIssueCounts.ToArray()));
+            }
+
+            var document = new DailyRecord
+            {
+                OrgAndRepo = $"{org}/{repo}",
+                Date = date,
+                Issues = productIssueCounts.ToArray()
+            };
+            return document;
+        }
+    }
+}

--- a/GitHub.RepositoryExplorer.Client/Services/IssueSnapshotsClient.cs
+++ b/GitHub.RepositoryExplorer.Client/Services/IssueSnapshotsClient.cs
@@ -15,31 +15,6 @@ public sealed class IssueSnapshotsClient
         _httpClient = factory.CreateClient(HttpClientNames.IssuesApi);
     }
 
-    public async Task<IEnumerable<IssuesSnapshot>?> GetSnapshotsForDateAsync(
-        Repository state, DateOnly date, RepoLabels labels)
-    {
-        var (org, repo) = (state.Org, state.Repo);
-        var route = _encode(date);
-        // TODO: This is going to be different for different graph sets
-        var allKeys = new List<SnapshotKey>();
-        foreach (var productKey in labels.IssueClassification.PriorityWithUnassigned())
-        {
-            allKeys.Add(new SnapshotKey(Product: productKey.Label,
-                Technology: null,
-                Priority: null,
-                Classification: null));
-        }
-        // end hack
-        var content = new StringContent(JsonSerializer.Serialize(allKeys), Encoding.UTF8, "application/json");
-        var response =
-            await _httpClient.PostAsync(
-                $"api/snapshots/{org}/{repo}/{route}", content);
-        response.EnsureSuccessStatusCode();
-        var jsonSnapshots = await response.Content.ReadAsStringAsync();
-
-        return JsonSerializer.Deserialize<IEnumerable<IssuesSnapshot>>(jsonSnapshots);
-    }
-
     public async Task<IEnumerable<IssuesSnapshot>?> GetIssuesForDateRangeAsync(
         Repository state, DateOnly from, DateOnly to, RepoLabels labels)
     {

--- a/GitHub.RepositoryExplorer.Client/Services/IssuesByPriorityClassification.cs
+++ b/GitHub.RepositoryExplorer.Client/Services/IssuesByPriorityClassification.cs
@@ -15,32 +15,6 @@ public sealed class IssuesByClassificationClient
         _httpClient = factory.CreateClient(HttpClientNames.IssuesApi);
     }
 
-    public async Task<IEnumerable<IssuesSnapshot>?> GetSnapshotsForDateAsync(
-        Repository state, DateOnly date, RepoLabels labels)
-    {
-        var (org, repo) = (state.Org, state.Repo);
-        var route = _encode(date);
-        // TODO: This is going to be different for different graph sets
-        var allKeys = new List<SnapshotKey>();
-        foreach (var classificationKey in labels.IssueClassification.ClassificationWithUnassigned())
-        {
-            allKeys.Add(new SnapshotKey(Product: null,
-                Technology: null,
-                Priority: null,
-                Classification: classificationKey.Label));
-        }
-        // end hack
-        var content = new StringContent(JsonSerializer.Serialize(allKeys), Encoding.UTF8, "application/json");
-        var response =
-            await _httpClient.PostAsync(
-                $"api/snapshots/{org}/{repo}/{route}", content);
-        response.EnsureSuccessStatusCode();
-        var jsonSnapshots = await response.Content.ReadAsStringAsync();
-
-        return JsonSerializer.Deserialize<IEnumerable<IssuesSnapshot>>(jsonSnapshots);
-    }
-
-    // Start here:
     public async Task<IEnumerable<IssuesSnapshot>?> GetIssuesForDateRangeAsync(
         Repository state, DateOnly from, DateOnly to, RepoLabels labels)
     {

--- a/GitHub.RepositoryExplorer.Client/Services/IssuesByPriorityClient.cs
+++ b/GitHub.RepositoryExplorer.Client/Services/IssuesByPriorityClient.cs
@@ -15,32 +15,6 @@ public sealed class IssuesByPriorityClient
         _httpClient = factory.CreateClient(HttpClientNames.IssuesApi);
     }
 
-    public async Task<IEnumerable<IssuesSnapshot>?> GetSnapshotsForDateAsync(
-        Repository state, DateOnly date, RepoLabels labels)
-    {
-        var (org, repo) = (state.Org, state.Repo);
-        var route = _encode(date);
-        // TODO: This is going to be different for different graph sets
-        var allKeys = new List<SnapshotKey>();
-        foreach (var priorityKey in labels.IssueClassification.PriorityWithUnassigned())
-        {
-            allKeys.Add(new SnapshotKey(Product: null,
-                Technology: null,
-                Priority: priorityKey.Label,
-                Classification: null));
-        }
-        // end hack
-        var content = new StringContent(JsonSerializer.Serialize(allKeys), Encoding.UTF8, "application/json");
-        var response =
-            await _httpClient.PostAsync(
-                $"api/snapshots/{org}/{repo}/{route}", content);
-        response.EnsureSuccessStatusCode();
-        var jsonSnapshots = await response.Content.ReadAsStringAsync();
-
-        return JsonSerializer.Deserialize<IEnumerable<IssuesSnapshot>>(jsonSnapshots);
-    }
-
-    // Start here:
     public async Task<IEnumerable<IssuesSnapshot>?> GetIssuesForDateRangeAsync(
         Repository state, DateOnly from, DateOnly to, RepoLabels labels)
     {

--- a/GitHub.RepositoryExplorer.Client/Services/IssuesClient.cs
+++ b/GitHub.RepositoryExplorer.Client/Services/IssuesClient.cs
@@ -15,28 +15,22 @@ public sealed class IssuesClient
     }
 
     public async Task<DailyRecord?> GetIssuesForDateAsync(
-        Repository state, DateOnly date)
+        Repository state, DateOnly date, IssueClassificationModel model)
     {
         var (org, repo) = (state.Org, state.Repo);
         var route =  _encode(date);
-        var dailyRecord =
-            await _httpClient.GetFromJsonAsync<DailyRecord>(
-                $"api/issues/{org}/{repo}/{route}");
+        try
+        {
+            var dailyRecord =
+                await _httpClient.GetFromJsonAsync<DailyRecord>(
+                    $"api/issues/{org}/{repo}/{route}");
 
-        return dailyRecord;
-    }
-
-    public async Task<IEnumerable<DailyRecord>?> GetIssuesForDateRangeAsync(
-        Repository state, DateOnly from, DateOnly to)
-    {
-        var (org, repo) = (state.Org, state.Repo);
-        var queryString =
-            $"from={_encode(from)}&to={_encode(to)}";
-
-        var dailyRecords =
-            await _httpClient.GetFromJsonAsync<IEnumerable<DailyRecord>>(
-                $"api/issues/{org}/{repo}?{queryString}");
-
-        return dailyRecords;
+            return dailyRecord;
+        }
+        catch ( Exception ex )
+        {
+            Console.WriteLine(ex);
+            return DailyRecordFactory.CreateMissingRecord(date, model, org, repo);
+        }
     }
 }

--- a/GitHub.RepositoryExplorer.Services/GitHub.RepositoryExplorer.Services.csproj
+++ b/GitHub.RepositoryExplorer.Services/GitHub.RepositoryExplorer.Services.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GitHub.RepositoryExplorer.WebApi/Controllers/IssueSnapshotsController.cs
+++ b/GitHub.RepositoryExplorer.WebApi/Controllers/IssueSnapshotsController.cs
@@ -47,13 +47,15 @@ public class IssueSnapshotsController : ControllerBase
         [FromQuery] string to,
         [FromBody] SnapshotKey[] allKeys)
     {
+        DateOnly fromDate = ParseDate(from);
+        DateOnly toDate = ParseDate(to);
         var dailyRecords = await _issueCountService.GetForRangeAsync(
-                org, repo, ParseDate(from), ParseDate(to)) ?? throw new InvalidOperationException("No data returned");
+                org, repo, fromDate, ParseDate(to)) ?? throw new InvalidOperationException("No data returned");
 
         var rVal = new List<IssuesSnapshot>();
         foreach (var key in allKeys)
         {
-            rVal.Add(dailyRecords.ToSnapshot(key));
+            rVal.Add(dailyRecords.ToSnapshot(key, fromDate, toDate));
         }
         return rVal;
     }


### PR DESCRIPTION
Because of a recent bad update to the Azure Function that loads data, several days counts are missing.

This provided an opportunity to add the needed resilience to the Blazor data display to correctly handle missing data:

- On the web service: If the data is missing for a given day, use `-1` for the issue count data.
- In all graphs, change the data sets from `int` to `double` and use `double.NaN` for missing data.
- In the table, add formatting information to display `?` when the requested data is wrong.