### PR TITLE
Correctly update Assignee and current iteration

### DIFF
--- a/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
@@ -59,14 +59,14 @@ public class JsonPatchDocument
     /// <summary>
     /// The old value (null is valid for many operations)
     /// </summary>
-    [JsonPropertyName("from")]
+    [JsonPropertyName("from"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? From { get; init; }
 
     /// <summary>
     /// The new value.
     /// </summary>
-    [JsonPropertyName("value")]
-    public required object? Value { get; init; }
+    [JsonPropertyName("value"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public object? Value { get; init; }
 }
 
 /// <summary>

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
@@ -59,6 +59,23 @@ public sealed class QuestClient : IDisposable
     }
 
     /// <summary>
+    /// Retrieve the JsonElement for all iterations in the project
+    /// </summary>
+    /// <returns>The JSON packet containing all iterations</returns>
+    public async Task<JsonElement> RetrieveAllIterations()
+    {
+        string getIterationsUrl =
+            $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/work/teamsettings/iterations?api-version=7.1-preview.1";
+        Console.WriteLine($"Get Iterations URL: \"{getIterationsUrl}\"");
+
+        using var response = await InitiateRequestAsync(
+            client => client.GetAsync(getIterationsUrl));
+
+        return await HandleResponseAsync(response);
+
+    }
+
+    /// <summary>
     /// Create a work item from an array of JsonPatch documents.
     /// </summary>
     /// <param name="document">The Json patch document that represents

--- a/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
@@ -1,0 +1,20 @@
+﻿namespace Quest2GitHub.Models;
+
+public class QuestIteration
+{
+    private const string PathTeam = "Content";
+    private const string YearPrefix = "CY_";
+    public required Guid Id { get; init; }
+    public required string Name { get; init; }
+    public required string Path { get; init; }
+
+    // Path format is "Content\\CY_YYYY\\MM MMM" (CY is calendar year)
+    // For example: "Content\\CY_2023\\03 Mar"
+    public static string CurrentIterationPath()
+    {
+        var currentYear = DateTime.Now.ToString("yyyy");
+        var sprintName = DateTime.Now.ToString("MM MMM");
+        return $"Content\\CY_{currentYear}\\{sprintName}";
+    }
+
+}

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -73,6 +73,7 @@ public class QuestWorkItem
     /// <param name="questClient">The quest client.</param>
     /// <param name="ospoClient">the MS open source programs office client.</param>
     /// <param name="path">The path component for the area path.</param>
+    /// <param name="currentIteration">The current AzDo iteration</param>
     /// <returns>The newly created linked Quest work item.</returns>
     /// <remarks>
     /// Fill in the Json patch document from the GitHub issue.
@@ -84,7 +85,8 @@ public class QuestWorkItem
         QuestClient questClient, 
         OspoClient ospoClient,
         string path,
-        string? requestLabelNodeId)
+        string? requestLabelNodeId,
+        QuestIteration currentIteration)
     {
         var areaPath = $"""{questClient.QuestProject}\{path}""";
 
@@ -129,6 +131,13 @@ public class QuestWorkItem
             Value = assigneeID
         };
         patchDocument.Add(assignPatch);
+        patchDocument.Add(new JsonPatchDocument
+        {
+            Operation = Op.Add,
+            Path = "/fields/System.IterationPath",
+            Value = currentIteration.Path,
+        });
+
         /* This is ignored by Azure DevOps. It uses the PAT of the 
          * account running the code.
         var creator = await issue.AuthorMicrosoftPreferredName(ospoClient);


### PR DESCRIPTION
There's one bug fix and one feature in this PR.

First, the Patch document isn't formatted correctly when un-assigning a Quest issue. The patch document needs to use the "Remove" operation.

Second, update the iteration on the following events:
1. Adding a new Quest item. If it is assigned, put it in the current iteration.
2. When a linked issue is opened / closed, put the associated quest item in the current iteration.

That code uses new query that retrieves all the current iterations when the app starts.