### PR TITLE
Better resiliency for paging queries

### DIFF
--- a/DotNet.DocsTools/GraphQLQueries/Common.cs
+++ b/DotNet.DocsTools/GraphQLQueries/Common.cs
@@ -17,5 +17,5 @@ public static class Common
 
     public static (bool hasNext, string endCursor) NextPageInfo(this JsonElement pageInfoNode) =>
         (pageInfoNode.Descendent("pageInfo", "hasNextPage").GetBoolean(), 
-        pageInfoNode.Descendent("pageInfo", "endCursor").GetString() ?? throw new InvalidOperationException("endCursor not present"));
+        pageInfoNode.Descendent("pageInfo", "endCursor").GetString() ?? string.Empty);
 }


### PR DESCRIPTION
See https://github.com/dotnet/dotnet-api-docs/actions/runs/4425065248/jobs/7759659474

There aren't any issues tagged yet in that repo, so the query returns no elements, `hasNextPage` is `false,` and the `endCursor` is `null`. That's OK, because when `hasNextPage` is null, all calls stop asking for more pages. But, the existing code throws an exception, and the run stops.