### PR TITLE
Authenticate Sequester using the org GitHub app token

### DIFF
--- a/DotNet.DocsTools/DotNet.DocsTools.csproj
+++ b/DotNet.DocsTools/DotNet.DocsTools.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="GitHubJwt" Version="0.0.5" />
 		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
 	</ItemGroup>

--- a/DotNet.DocsTools/DotNet.DocsTools.csproj
+++ b/DotNet.DocsTools/DotNet.DocsTools.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyVersion>2.0.0.3</AssemblyVersion>
-    <FileVersion>2.0.0.3</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DotNet.DocsTools/GitHubClientServices/GitHubAppClient.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubAppClient.cs
@@ -12,15 +12,6 @@ internal class GitHubAppClient : GitHubClientBase, IGitHubClient, IDisposable
     private Task regenerateTask = default!;
     private CancellationTokenSource? _tokenSource;
 
-    public sealed class PlainStringPrivateKeySource : IPrivateKeySource
-    {
-        private readonly string _key;
-
-        public PlainStringPrivateKeySource(string key) => _key = key;
-
-        public TextReader GetPrivateKeyReader() => new StringReader(_key);
-    }
-
     internal GitHubAppClient(int appID, string oauthPrivateKey) =>
         (_appID, _oauthPrivateKey) = (appID, oauthPrivateKey);
 
@@ -67,3 +58,14 @@ internal class GitHubAppClient : GitHubClientBase, IGitHubClient, IDisposable
         base.Dispose();
     }
 }
+
+file sealed class PlainStringPrivateKeySource : IPrivateKeySource
+{
+    private readonly string _key;
+
+    public PlainStringPrivateKeySource(string key) => _key = key;
+
+    public TextReader GetPrivateKeyReader() => new StringReader(_key);
+}
+
+

--- a/DotNet.DocsTools/GitHubClientServices/GitHubAppClient.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubAppClient.cs
@@ -1,0 +1,56 @@
+﻿using DotNetDocs.Tools.GitHubCommunications;
+using GitHubJwt;
+using System.Net.Http.Headers;
+
+namespace DotNet.DocsTools.GitHubClientServices;
+
+internal class GitHubAppClient : GitHubClientBase, IGitHubClient, IDisposable
+{
+    private readonly int _appID;
+    private readonly string _oauthPrivateKey;
+
+    private Task regenerateTask = default!;
+
+    public sealed class PlainStringPrivateKeySource : IPrivateKeySource
+    {
+        private readonly string _key;
+
+        public PlainStringPrivateKeySource(string key) => _key = key;
+
+        public TextReader GetPrivateKeyReader() => new StringReader(_key);
+    }
+
+    internal GitHubAppClient(int appID, string oauthPrivateKey) =>
+        (_appID, _oauthPrivateKey) = (appID, oauthPrivateKey);
+
+    internal async Task GenerateTokenAsync()
+    {
+        var privateKeySource = new PlainStringPrivateKeySource(_oauthPrivateKey);
+        var generator = new GitHubJwtFactory(
+            privateKeySource,
+            new GitHubJwtFactoryOptions
+            {
+                AppIntegrationId = _appID,
+                ExpirationSeconds = 8 * 60 // 600 is apparently too high
+            });
+
+        var token = generator.CreateEncodedJwtToken();
+        SetAuthorizationHeader(new AuthenticationHeaderValue("Bearer", token));
+
+        var installationId = await RetrieveInstallationIDAsync();
+
+        var (oauthToken, timeout) = await RetrieveAuthTokenAsync(installationId);
+
+        SetAuthorizationHeader(new AuthenticationHeaderValue("Token", oauthToken));
+
+        timeout = timeout - TimeSpan.FromMinutes(5);
+        // Don't await. Fire and store:
+        regenerateTask = RegenerateTokenAfter(timeout);
+    }
+
+    private async Task RegenerateTokenAfter(TimeSpan duration)
+    {
+        await Task.Delay(duration);
+        await GenerateTokenAsync();
+    }
+}

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClient.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClient.cs
@@ -10,7 +10,6 @@ public sealed class GitHubClient : IGitHubClient, IDisposable
 {
     private const string ProductID = "DotNetDocs.Tools";
     private const string ProductVersion = "2.0";
-    private static readonly Uri markdownUri = new("https://api.github.com/markdown");
     private static readonly Uri graphQLUri = new("https://api.github.com/graphql");
     private const string RESTendpoint = "https://api.github.com/repos";
     private readonly HttpClient _client;
@@ -30,6 +29,7 @@ public sealed class GitHubClient : IGitHubClient, IDisposable
             })
             .WaitAndRetryAsync(delay);
     }
+
     async Task<JsonElement> IGitHubClient.PostGraphQLRequestAsync(GraphQLPacket queryText)
     {
         using var request = new StringContent(queryText.ToJsonText());
@@ -46,23 +46,7 @@ public sealed class GitHubClient : IGitHubClient, IDisposable
         else
             return root.GetProperty("data");
     }
-    /*
-    async Task<string> IGitHubClient.PostMarkdownRESTRequestAsync(string markdownText)
-    {
-        var requestBody = new MarkdownToHtmlRequest
-        {
-            text = markdownText
-        };
-        using var request = new StringContent(requestBody.ToJsonText());
-        request.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Json);
-        request.Headers.Add("Accepts", MediaTypeNames.Text.Html);
-        var result = await _retryPolicy.ExecuteAndCaptureAsync(
-            () => _client.PostAsync(markdownUri, request));
-        using var resp = result.Result;
-        var stringResponse = await resp.Content.ReadAsStringAsync();
-        return stringResponse;
-    }
-    */
+
     async Task<JsonDocument> IGitHubClient.GetReposRESTRequestAsync(params string[] restPath)
     {
         var url = RESTendpoint;
@@ -80,28 +64,5 @@ public sealed class GitHubClient : IGitHubClient, IDisposable
         return jsonDocument;
     }
 
-    /*
-    async IAsyncEnumerable<string> IGitHubClient.GetContentAsync(string link)
-    {
-        var result = await _retryPolicy.ExecuteAndCaptureAsync(
-            () => _client.GetAsync(link));
-        using var response = result.Result;
-
-        if (!response.IsSuccessStatusCode)
-            yield return "";
-        else
-        {
-            using var responseStream = await response.Content.ReadAsStreamAsync();
-            using StreamReader reader = new(responseStream);
-            var line = await reader.ReadLineAsync();
-            while (line != null)
-            {
-                yield return line;
-                line = await reader.ReadLineAsync();
-            }
-        }
-    }
-
-    */
     public void Dispose() => _client?.Dispose();
 }

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClient.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClient.cs
@@ -1,68 +1,10 @@
-﻿using Polly.Contrib.WaitAndRetry;
-using Polly;
-using Polly.Retry;
-using System.Net.Http.Headers;
-using System.Net.Mime;
-using System.Text.Json;
+﻿using System.Net.Http.Headers;
 
 namespace DotNetDocs.Tools.GitHubCommunications;
-public sealed class GitHubClient : IGitHubClient, IDisposable
+public sealed class GitHubClient : GitHubClientBase, IGitHubClient, IDisposable
 {
-    private const string ProductID = "DotNetDocs.Tools";
-    private const string ProductVersion = "2.0";
-    private static readonly Uri graphQLUri = new("https://api.github.com/graphql");
-    private const string RESTendpoint = "https://api.github.com/repos";
-    private readonly HttpClient _client;
-    private readonly AsyncRetryPolicy _retryPolicy;
     internal GitHubClient(string token)
     {
-        _client = new HttpClient();
-        _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", token);
-        _client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ProductID, ProductVersion));
-        var delay = Backoff.DecorrelatedJitterBackoffV2(
-            medianFirstRetryDelay: TimeSpan.FromSeconds(15), retryCount: 5);
-        _retryPolicy = Policy
-            .Handle<HttpRequestException>(ex =>
-            {
-                Console.WriteLine($"::warning::{ex}");
-                return true;
-            })
-            .WaitAndRetryAsync(delay);
+        SetAuthorizationHeader(new AuthenticationHeaderValue("Token", token));
     }
-
-    async Task<JsonElement> IGitHubClient.PostGraphQLRequestAsync(GraphQLPacket queryText)
-    {
-        using var request = new StringContent(queryText.ToJsonText());
-        request.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Json);
-        request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
-        var result = await _retryPolicy.ExecuteAndCaptureAsync(
-            () => _client.PostAsync(graphQLUri, request));
-
-        using var resp = result.Result;
-        var jsonDocument = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
-        var root = jsonDocument.RootElement;
-        if (root.TryGetProperty("errors", out var errorList))
-            throw new InvalidOperationException(errorList.GetRawText());
-        else
-            return root.GetProperty("data");
-    }
-
-    async Task<JsonDocument> IGitHubClient.GetReposRESTRequestAsync(params string[] restPath)
-    {
-        var url = RESTendpoint;
-        foreach (var component in restPath)
-            url += "/" + component;
-        // Default single page result is 30, specify max items per page (100)
-        url += "?per_page=100";
-        var result = await _retryPolicy.ExecuteAndCaptureAsync(
-            () => _client.GetAsync(url));
-        using var response = result.Result;
-
-        if (!response.IsSuccessStatusCode)
-            throw new InvalidOperationException($"REST request failed for {url}");
-        var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
-        return jsonDocument;
-    }
-
-    public void Dispose() => _client?.Dispose();
 }

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
@@ -81,7 +81,7 @@ public abstract class GitHubClientBase : IGitHubClient, IDisposable
     {
         var url = RESTendpoint;
         foreach (var component in restPath)
-            url += "/" + component;
+            url += %"/{component}";
         // Default single page result is 30, specify max items per page (100)
         url += "?per_page=100";
         var result = await _retryPolicy.ExecuteAndCaptureAsync(

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
@@ -1,0 +1,98 @@
+﻿using Polly.Contrib.WaitAndRetry;
+using Polly.Retry;
+using Polly;
+using System.Net.Http.Headers;
+using System.Net.Mime;
+using System.Text.Json;
+
+namespace DotNetDocs.Tools.GitHubCommunications;
+
+public abstract class GitHubClientBase : IGitHubClient, IDisposable
+{
+    private const string ProductID = "DotNetDocs.Tools";
+    private const string ProductVersion = "2.0";
+    private const string RESTendpoint = "https://api.github.com/repos";
+    private static readonly Uri graphQLUri = new("https://api.github.com/graphql");
+    private readonly HttpClient _client = new HttpClient();
+    private readonly AsyncRetryPolicy _retryPolicy;
+   
+    internal GitHubClientBase()
+    {
+        _client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ProductID, ProductVersion));
+        var delay = Backoff.DecorrelatedJitterBackoffV2(
+            medianFirstRetryDelay: TimeSpan.FromSeconds(15), retryCount: 5);
+        _retryPolicy = Policy
+            .Handle<HttpRequestException>(ex =>
+            {
+                Console.WriteLine($"::warning::{ex}");
+                return true;
+            })
+            .WaitAndRetryAsync(delay);
+    }
+
+    protected void SetAuthorizationHeader(AuthenticationHeaderValue Header) =>
+        _client.DefaultRequestHeaders.Authorization = Header;
+
+    protected async Task<int> RetrieveInstallationIDAsync()
+    {
+        using var response = await _client.GetAsync("https://api.github.com/app/installations");
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"REST request failed for app installations");
+        var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        var installationId = jsonDocument.RootElement[0].GetProperty("id").GetInt32();
+        return installationId;
+    }
+
+    protected async Task<(string oauthTokentoken, TimeSpan timeout)> RetrieveAuthTokenAsync(int installationID)
+    {
+        var tokenUrl = $"https://api.github.com/app/installations/{installationID}/access_tokens";
+        using var emptyPacket = new StringContent("");
+        using var tokenResponse = await _client.PostAsync(tokenUrl, emptyPacket);
+        if (!tokenResponse.IsSuccessStatusCode)
+            throw new InvalidOperationException($"REST request failed for app installations");
+        var jsonDocument = await JsonDocument.ParseAsync(await tokenResponse.Content.ReadAsStreamAsync());
+
+        var oauthToken = jsonDocument.RootElement.GetProperty("token").GetString() ??
+            throw new ArgumentNullException("oauth token not found");
+        var expiration = jsonDocument.RootElement.GetProperty("expires_at").GetString();
+        var duration = (expiration is not null) ? DateTime.Parse(expiration) - DateTime.Now : TimeSpan.FromMinutes(50);
+        return (oauthToken, duration);
+    }
+
+    async Task<JsonElement> IGitHubClient.PostGraphQLRequestAsync(GraphQLPacket queryText)
+    {
+        using var request = new StringContent(queryText.ToJsonText());
+        request.Headers.ContentType = new MediaTypeHeaderValue(MediaTypeNames.Application.Json);
+        request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
+        var result = await _retryPolicy.ExecuteAndCaptureAsync(
+            () => _client.PostAsync(graphQLUri, request));
+
+        using var resp = result.Result;
+        var jsonDocument = await JsonDocument.ParseAsync(await resp.Content.ReadAsStreamAsync());
+        var root = jsonDocument.RootElement;
+        if (root.TryGetProperty("errors", out var errorList))
+            throw new InvalidOperationException(errorList.GetRawText());
+        else
+            return root.GetProperty("data");
+    }
+
+    async Task<JsonDocument> IGitHubClient.GetReposRESTRequestAsync(params string[] restPath)
+    {
+        var url = RESTendpoint;
+        foreach (var component in restPath)
+            url += "/" + component;
+        // Default single page result is 30, specify max items per page (100)
+        url += "?per_page=100";
+        var result = await _retryPolicy.ExecuteAndCaptureAsync(
+            () => _client.GetAsync(url));
+        using var response = result.Result;
+
+        if (!response.IsSuccessStatusCode)
+            throw new InvalidOperationException($"REST request failed for {url}");
+        var jsonDocument = await JsonDocument.ParseAsync(await response.Content.ReadAsStreamAsync());
+        return jsonDocument;
+    }
+
+    public void Dispose() => _client?.Dispose();
+}

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
@@ -13,7 +13,7 @@ public abstract class GitHubClientBase : IGitHubClient, IDisposable
     private const string ProductVersion = "2.0";
     private const string RESTendpoint = "https://api.github.com/repos";
     private static readonly Uri graphQLUri = new("https://api.github.com/graphql");
-    private readonly HttpClient _client = new HttpClient();
+    private readonly HttpClient _client = new();
     private readonly AsyncRetryPolicy _retryPolicy;
    
     internal GitHubClientBase()

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
@@ -81,7 +81,7 @@ public abstract class GitHubClientBase : IGitHubClient, IDisposable
     {
         var url = RESTendpoint;
         foreach (var component in restPath)
-            url += %"/{component}";
+            url += $"/{component}";
         // Default single page result is 30, specify max items per page (100)
         url += "?per_page=100";
         var result = await _retryPolicy.ExecuteAndCaptureAsync(

--- a/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
+++ b/DotNet.DocsTools/GitHubClientServices/GitHubClientBase.cs
@@ -94,5 +94,5 @@ public abstract class GitHubClientBase : IGitHubClient, IDisposable
         return jsonDocument;
     }
 
-    public void Dispose() => _client?.Dispose();
+    public virtual void Dispose() => _client?.Dispose();
 }

--- a/actions/sequester/ImportIssues/ImportIssues.csproj
+++ b/actions/sequester/ImportIssues/ImportIssues.csproj
@@ -6,8 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
-    <AssemblyVersion>2.0.0.1</AssemblyVersion>
-    <FileVersion>2.0.0.1</FileVersion>
+    <AssemblyVersion>2.1.0.0</AssemblyVersion>
+    <FileVersion>2.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -8,7 +8,6 @@ internal class Program
     /// </summary>
     /// <param name="org">The GitHub organization</param>
     /// <param name="repo">The GutHub repository names.</param>
-    /// <param name="appid">The GitHub App ID</param>
     /// <param name="issue">The issue number. If null, process all open issues.</param>
     /// <param name="questConfigPath">The config path. If null, use the config file in the root folder of the repository.</param>
     /// <param name="branch">The optional branch to use. Defaults to "main" otherwise.</param>
@@ -21,7 +20,6 @@ internal class Program
     private static async Task<int> Main(
         string org,
         string repo,
-        int? appid = null,
         int? issue = null,
         int? duration = 5,
         string? questConfigPath = null,
@@ -60,9 +58,6 @@ internal class Program
                     $"Unable to load Quest import configuration options.");
             }
 
-            // TODO: Read from config file
-            importOptions.AppId = appid ?? 0;
-
             bool singleIssue = (issue is not null && issue.Value != -1);
 
             using var serviceWorker = await CreateService(importOptions, !singleIssue);
@@ -90,8 +85,8 @@ internal class Program
     {
         ArgumentNullException.ThrowIfNull(options.ApiKeys, nameof(options));
 
-        IGitHubClient gitHubClient = (options.AppId != 0) 
-            ? await IGitHubClient.CreateGitHubAppClient(options.AppId, options.ApiKeys.SequesterPrivateKey)
+        IGitHubClient gitHubClient = (options.ApiKeys.SequesterAppID != 0) 
+            ? await IGitHubClient.CreateGitHubAppClient(options.ApiKeys.SequesterAppID, options.ApiKeys.SequesterPrivateKey)
             : IGitHubClient.CreateGitHubClient(options.ApiKeys.GitHubToken);
 
         return new QuestGitHubService(

--- a/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
@@ -107,7 +107,7 @@ public class ImportOptionsTests
         {
             ApiKeys = new()
             {
-                GitHubToken = "", OSPOKey = " ", QuestKey = " "
+                GitHubToken = "", OSPOKey = " ", QuestKey = " ", SequesterPrivateKey = " "
             }
         };
 

--- a/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
@@ -107,7 +107,7 @@ public class ImportOptionsTests
         {
             ApiKeys = new()
             {
-                GitHubToken = "", OSPOKey = " ", QuestKey = " ", SequesterPrivateKey = " "
+                GitHubToken = "", OSPOKey = " ", QuestKey = " ", SequesterPrivateKey = " ", SequesterAppID = 0
             }
         };
 

--- a/actions/sequester/Quest2GitHub/EnumerateIssues.cs
+++ b/actions/sequester/Quest2GitHub/EnumerateIssues.cs
@@ -30,11 +30,23 @@ public class EnumerateIssues
                     name
                   }
                 }
-                projectsV2 {
-                  totalCount
-                }
-                projectItems {
-                  totalCount
+                projectItems(first: 25) {
+                  ... on ProjectV2ItemConnection {
+                    nodes {
+                      ... on ProjectV2Item {
+                        fieldValueByName(name:"Size") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                          }
+                        }
+                        project {
+                          ... on ProjectV2 {
+                            title
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
                 bodyHTML
                 body

--- a/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
@@ -111,6 +111,7 @@ public static class ImportOptionsExtensions
             {
                 ApiKeys = new()
                 {
+                    SequesterPrivateKey = "",
                     GitHubToken = "",
                     OSPOKey = "",
                     QuestKey = ""

--- a/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
@@ -114,7 +114,8 @@ public static class ImportOptionsExtensions
                     SequesterPrivateKey = "",
                     GitHubToken = "",
                     OSPOKey = "",
-                    QuestKey = ""
+                    QuestKey = "",
+                    SequesterAppID = 0
                 }
             };
         }

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -220,14 +220,20 @@ public class GithubIssue
         {
             foreach (var projectItem in issueNode.Descendent("projectItems", "nodes").EnumerateArray())
             {
-                var projectTitle = projectItem.Descendent("project", "title").GetString();
-                // size may or may not have been set yet:
-                var sizeNode = projectItem.Descendent("fieldValueByName", "name");
-
-                var size = (sizeNode.ValueKind is JsonValueKind.String) ? sizeNode.GetString() : null;
-                if ((projectTitle is not null) && (size is not null))
+                if (projectItem.ValueKind == JsonValueKind.Object)
                 {
-                    storyPoints.Add(new StoryPointSize(projectTitle, size));
+                    // TODO: MAUI uses one sprint project per year, with a field for the month.
+                    // Modify the code to store the optional month in the tuple field.
+                    // Consider: Store YYYY, Month, Size as a threeple.
+                    var projectTitle = projectItem.Descendent("project", "title").GetString();
+                    // size may or may not have been set yet:
+                    var sizeNode = projectItem.Descendent("fieldValueByName", "name");
+
+                    var size = (sizeNode.ValueKind is JsonValueKind.String) ? sizeNode.GetString() : null;
+                    if ((projectTitle is not null) && (size is not null))
+                    {
+                        storyPoints.Add(new StoryPointSize(projectTitle, size));
+                    }
                 }
             }
         }

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -259,11 +259,13 @@ public class GithubIssue
                 }
             }
         }
+        // Timeline events are in order, so the last PR is the most recent closing PR
         var closedEvent = issueNode.Descendent("timelineItems", "nodes").EnumerateArray()
-            .FirstOrDefault(t =>
+            .LastOrDefault(t =>
             (t.TryGetProperty("closer", out var closer) &&
             closer.ValueKind == JsonValueKind.Object));
-        string? closingPR = (closedEvent.ValueKind == JsonValueKind.Object) 
+        // check state. If re-opened, don't reference the (not correct) closing PR
+        string? closingPR = ((closedEvent.ValueKind == JsonValueKind.Object) && !isOpen ) 
             ? closedEvent.Descendent("closer", "url").GetString() 
             : default;
 

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -160,6 +160,14 @@ public class QuestWorkItem
                 Value = "Closed",
             });
         }
+
+        // Size mapping:
+
+        // "Tiny" => 1
+        // "small" => 3
+        // "Medium" => 5
+        // "Large" => 8
+        // "X-Large" => 13
         JsonElement result = default;
         try
         {

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -1,7 +1,4 @@
-﻿using Quest2GitHub.AzureDevOpsCommunications;
-using System.IO;
-
-namespace Quest2GitHub.Models;
+﻿namespace Quest2GitHub.Models;
 
 public class QuestWorkItem
 {

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -50,6 +50,14 @@ public class QuestWorkItem
     /// This is retrieved as /fields/System.State
     /// </remarks>
     public required string? State { get; init; }
+
+    /// <summary>
+    /// The story point value.
+    /// </summary>
+    /// <remarks>
+    /// This is retrieved from /Microsoft.VSTS.Scheduling.StoryPoints
+    /// </remarks>
+    public required int StoryPoints { get; init; }
     
     /// <summary>
     /// Create a work item object from the ID
@@ -165,6 +173,14 @@ public class QuestWorkItem
         // "Medium" => 5
         // "Large" => 8
         // "X-Large" => 13
+
+        // TODO:  
+        // 1. Read the project / size pairs. 
+        // 2. Find the *latest* sprint project.
+        // 3. Set the iteration to the latest sprint.
+        // 4. Set the size based on the size field.
+        // 5. Change the iteration code above to use the latest iteration
+        // for the issue.
         JsonElement result = default;
         try
         {
@@ -230,6 +246,7 @@ public class QuestWorkItem
         var areaPath = fields.GetProperty("System.AreaPath").GetString()!;
         var iterationPath = fields.GetProperty("System.IterationPath").GetString();
         var assignedNode = fields.Descendent("System.AssignedTo", "id");
+        var storyPoints = fields.GetProperty("Microsoft.VSTS.Scheduling.StoryPoints").GetDouble();
         var assignedID = (assignedNode.ValueKind is JsonValueKind.String) ?
             assignedNode.GetString() : null;
         return new QuestWorkItem
@@ -240,7 +257,8 @@ public class QuestWorkItem
             Description = description,
             AreaPath = areaPath,
             IterationPath = iterationPath,
-            AssignedToId = (assignedID is not null) ? new Guid(assignedID) : null
+            AssignedToId = (assignedID is not null) ? new Guid(assignedID) : null,
+            StoryPoints = (int)double.Truncate(storyPoints)
         };
     }
 

--- a/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
+++ b/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
@@ -47,4 +47,16 @@ public sealed record class ApiKeys
     /// </code>
     /// </remarks>
     public required string QuestKey { get; init; }
+
+    /// <summary>
+    /// The OAuth Private key to authenticate this app
+    /// </summary>
+    /// <remarks>
+    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__SequesterPrivateKey</c>:
+    /// <code>
+    /// env:
+    ///   ImportOptions__ApiKeys__SequesterPrivateKey: ${{ secrets.SEQUESTER_PRIVATEKEY }}
+    /// </code>
+    /// </remarks>
+    public required string SequesterPrivateKey { get; init; }
 }

--- a/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
+++ b/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
@@ -59,4 +59,16 @@ public sealed record class ApiKeys
     /// </code>
     /// </remarks>
     public required string SequesterPrivateKey { get; init; }
+
+    /// <summary>
+    /// The Sequester GitHub App ID
+    /// </summary>
+    /// <remarks>
+    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__SequesterAppID</c>:
+    /// <code>
+    /// env:
+    ///   ImportOptions__ApiKeys__SequesterAppID: ${{ secrets.SEQUESTER_APPID }}
+    /// </code>
+    /// </remarks>
+    public required int SequesterAppID { get; init; }
 }

--- a/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
+++ b/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
@@ -7,9 +7,10 @@ internal sealed class EnvironmentVariableReader
         var githubToken = CoalesceEnvVar(("ImportOptions__ApiKeys__GitHubToken", "GitHubKey"));
         var ospoKey = CoalesceEnvVar(("ImportOptions__ApiKeys__OSPOKey", "OSPOKey"));
         var questKey = CoalesceEnvVar(("ImportOptions__ApiKeys__QuestKey", "QuestKey"));
-        var oauthPrivateKey = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterPrivateKey", "SequesterPrivateKey"));
-
-        var appIDString = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterAppID", "SequesterAppID"));
+        // These keys are used when the app is run as an org enabled action. They are optional. 
+        // If missing, the action runs using repo-only rights.
+        var oauthPrivateKey = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterPrivateKey", "SequesterPrivateKey"), false);
+        var appIDString = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterAppID", "SequesterAppID"), false);
         if (!int.TryParse(appIDString, out int appID)) appID = 0;
 
         return new ApiKeys()
@@ -22,7 +23,7 @@ internal sealed class EnvironmentVariableReader
         };
     }
 
-    static string CoalesceEnvVar((string preferredKey, string fallbackKey) keys)
+    static string CoalesceEnvVar((string preferredKey, string fallbackKey) keys, bool required = true)
     {
         var (preferredKey, fallbackKey) = keys;
 
@@ -30,7 +31,7 @@ internal sealed class EnvironmentVariableReader
         if (string.IsNullOrWhiteSpace(value))
         {
             value = Environment.GetEnvironmentVariable(fallbackKey);
-            if (string.IsNullOrWhiteSpace(value))
+            if (string.IsNullOrWhiteSpace(value) && required)
             {
                 throw new Exception(
                     $"Missing env var, checked for both: {preferredKey} and {fallbackKey}.");

--- a/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
+++ b/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
@@ -7,12 +7,14 @@ internal sealed class EnvironmentVariableReader
         var githubToken = CoalesceEnvVar(("ImportOptions__ApiKeys__GitHubToken", "GitHubKey"));
         var ospoKey = CoalesceEnvVar(("ImportOptions__ApiKeys__OSPOKey", "OSPOKey"));
         var questKey = CoalesceEnvVar(("ImportOptions__ApiKeys__QuestKey", "QuestKey"));
+        var oauthPrivateKey = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterPrivateKey", "SequesterPrivateKey"));
 
         return new ApiKeys()
         {
             GitHubToken = githubToken,
             OSPOKey = ospoKey,
-            QuestKey = questKey
+            QuestKey = questKey,
+            SequesterPrivateKey = oauthPrivateKey
         };
     }
 

--- a/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
+++ b/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
@@ -9,12 +9,16 @@ internal sealed class EnvironmentVariableReader
         var questKey = CoalesceEnvVar(("ImportOptions__ApiKeys__QuestKey", "QuestKey"));
         var oauthPrivateKey = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterPrivateKey", "SequesterPrivateKey"));
 
+        var appIDString = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterAppID", "SequesterAppID"));
+        if (!int.TryParse(appIDString, out int appID)) appID = 0;
+
         return new ApiKeys()
         {
             GitHubToken = githubToken,
             OSPOKey = ospoKey,
             QuestKey = questKey,
-            SequesterPrivateKey = oauthPrivateKey
+            SequesterPrivateKey = oauthPrivateKey,
+            SequesterAppID = appID
         };
     }
 

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -42,9 +42,4 @@ public sealed record class ImportOptions
     /// <a href="https://github.com/ikatyang/emoji-cheat-sheet"></a>
     /// </remarks>
     public required string ImportedLabel { get; init; } = ":pushpin: seQUESTered";
-
-    /// <summary>
-    /// The GitHub APP id for use as a GitHub ap
-    /// </summary>
-    public int AppId { get; set; } = 0;
 }

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -42,4 +42,9 @@ public sealed record class ImportOptions
     /// <a href="https://github.com/ikatyang/emoji-cheat-sheet"></a>
     /// </remarks>
     public required string ImportedLabel { get; init; } = ":pushpin: seQUESTered";
+
+    /// <summary>
+    /// The GitHub APP id for use as a GitHub ap
+    /// </summary>
+    public int AppId { get; set; } = 0;
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -297,6 +297,8 @@ public class QuestGitHubService : IDisposable
                 Value = ghIssue.IsOpen ? "Active" : "Closed",
             });
 
+            // TODO: Update to the latest iteration in the GH issue.
+            // TODO: Update the size from the configured size in the GH issue and the latest iteration.
             // Update to the current sprint when an item is closed, or reopened:
             patchDocument.Add(new JsonPatchDocument
             {

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -26,7 +26,7 @@ public class QuestGitHubService : IDisposable
     /// <summary>
     /// Initialize the service.
     /// </summary>
-    /// <param name="ghKey">GitHub personal access token</param>
+    /// <param name="client">GitHub client</param>
     /// <param name="ospoKey">MS Open Source Programs Office personal access token</param>
     /// <param name="azdoKey">Azure Dev Ops personal access token</param>
     /// <param name="questOrg">The Azure Dev ops organization</param>
@@ -35,8 +35,12 @@ public class QuestGitHubService : IDisposable
     /// <param name="importTriggerLabel">The text of the label that triggers an import</param>
     /// <param name="importedLabel">The text of the label that indicates an issue has been imported</param>
     /// <param name="bulkImport">True if this run is doing a bulk import.</param>
+    /// <remarks>
+    /// The OAuth token takes precendence over the github token, if both are 
+    /// present.
+    /// </remarks>
     public QuestGitHubService(
-        string ghKey,
+        IGitHubClient client,
         string ospoKey,
         string azdoKey,
         string questOrg,
@@ -46,7 +50,7 @@ public class QuestGitHubService : IDisposable
         string importedLabel,
         bool bulkImport)
     {
-        _ghClient = IGitHubClient.CreateGitHubClient(ghKey);
+        _ghClient = client;
         _ospoClient = new OspoClient(ospoKey, bulkImport);
         _azdoClient = new QuestClient(azdoKey, questOrg, questProject);
         _areaPath = areaPath;
@@ -88,7 +92,8 @@ public class QuestGitHubService : IDisposable
 
             if (item.Labels.Any(l => (l.nodeID == _importTriggerLabel?.nodeID) || (l.nodeID == _importedLabel?.nodeID)))
             {
-                Console.WriteLine($"{item.IssueNumber}: {item.Title}");
+                // Console.WriteLine($"{item.IssueNumber}: {item.Title}");
+                Console.WriteLine(item);
                 var questItem = await FindLinkedWorkItem(item);
                 if (dryRun is false)
                 {


### PR DESCRIPTION
Update the code to use the org-configured GitHub app. 

Contributes to #177 

First, create a GitHub client that uses the org-level AppID and GitHub app secret. Write this code so that if the necessary secret isn't configured, fallback to the existing PAT. 

Update the query to read issues to additionally read the associated project and project fields. Those fields are only returned when using the updated app token. The code here optionally fills in those fields in the GitHub issue object if they are present. If not, the list of story point nodes is empty.
