### PR TITLE
Update story points and iteration in Quest

### DIFF
--- a/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
@@ -69,6 +69,18 @@ public class JsonPatchDocument
     public object? Value { get; init; }
 }
 
+public class Relation
+{
+    [JsonPropertyName("rel")]
+    public string RelationName { get; init; } = "ArtifactLink";
+
+    [JsonPropertyName("url")]
+    public required string Url { get; init; }
+
+    [JsonPropertyName("attributes")]
+    public IDictionary<string, object> Attributes{ get; } = new Dictionary<string, object>();
+
+}
 /// <summary>
 /// The fields required to Assign to an identity
 /// </summary>

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/JsonPatchDocument.cs
@@ -78,8 +78,7 @@ public class Relation
     public required string Url { get; init; }
 
     [JsonPropertyName("attributes")]
-    public IDictionary<string, object> Attributes{ get; } = new Dictionary<string, object>();
-
+    public IDictionary<string, object> Attributes{ get; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 }
 /// <summary>
 /// The fields required to Assign to an identity

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -264,7 +264,9 @@ public class GithubIssue
                             if (fieldName == "Size") size = fieldValue.GetString();
                         }
                     }
-                    if ((projectTitle is not null) && (size is not null))
+                    if ((projectTitle is not null) && 
+                        (size is not null) &&
+                        projectTitle.ToLower().Contains("sprint"))
                     {
                         string[] components = projectTitle.Split(' ');
                         int yearIndex = (sprintMonth is null) ? 2 : 1;

--- a/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
+++ b/actions/sequester/Quest2GitHub/Models/GithubIssue.cs
@@ -1,7 +1,4 @@
-﻿using Org.BouncyCastle.Asn1.Mozilla;
-using System.Xml.Linq;
-
-namespace Quest2GitHub.Models;
+﻿namespace Quest2GitHub.Models;
 
 /// <summary>
 /// Simple record type for a GitHub label
@@ -13,9 +10,10 @@ public record GitHubLabel(string name, string nodeID);
 /// <summary>
 /// Record type to store a project name / story point size pair
 /// </summary>
-/// <param name="ProjectName">The name of the GitHub org project</param>
+/// <param name="CalendarYear">The calendar year</param>
+/// <param name="Month">The 3 character month code</param>
 /// <param name="Size">The value of the "size" special field</param>
-public record StoryPointSize(string ProjectName, string Size);
+public record StoryPointSize(int CalendarYear, string Month, string Size);
 
 /// <summary>
 /// Model for a GitHub issue
@@ -55,9 +53,16 @@ public class GithubIssue
             ... on ProjectV2ItemConnection {
               nodes {
                 ... on ProjectV2Item {
-                  fieldValueByName(name:"Size") {
-                    ... on ProjectV2ItemFieldSingleSelectValue {
-                      name
+                  fieldValues(first:10) {
+                    nodes {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        field {
+                          ... on ProjectV2FieldCommon {
+                            name
+                          }
+                        }
+                        name
+                      }
                     }
                   }
                   project {
@@ -244,17 +249,29 @@ public class GithubIssue
             {
                 if (projectItem.ValueKind == JsonValueKind.Object)
                 {
-                    // TODO: MAUI uses one sprint project per year, with a field for the month.
                     // Modify the code to store the optional month in the tuple field.
                     // Consider: Store YYYY, Month, Size as a threeple.
                     var projectTitle = projectItem.Descendent("project", "title").GetString();
                     // size may or may not have been set yet:
-                    var sizeNode = projectItem.Descendent("fieldValueByName", "name");
-
-                    var size = (sizeNode.ValueKind is JsonValueKind.String) ? sizeNode.GetString() : null;
+                    string? size = default;
+                    string? sprintMonth = default;
+                    foreach(var field in projectItem.Descendent("fieldValues", "nodes").EnumerateArray())
+                    {
+                        if (field.TryGetProperty("name", out var fieldValue))
+                        {
+                            var fieldName = field.Descendent("field", "name").GetString();
+                            if (fieldName == "Sprint") sprintMonth = fieldValue.GetString();
+                            if (fieldName == "Size") size = fieldValue.GetString();
+                        }
+                    }
                     if ((projectTitle is not null) && (size is not null))
                     {
-                        storyPoints.Add(new StoryPointSize(projectTitle, size));
+                        string[] components = projectTitle.Split(' ');
+                        int yearIndex = (sprintMonth is null) ? 2 : 1;
+                        // Should be in a project variable named "Sprint", take substring 0,3
+                        var Month = sprintMonth ?? components[1].Substring(0, 3);
+                        int.TryParse(components[yearIndex], out var year); 
+                        storyPoints.Add(new StoryPointSize(year, Month.Substring(0,3), size));
                     }
                 }
             }
@@ -331,7 +348,7 @@ public class GithubIssue
         Open: {{IsOpen}}
         Assignees: {{String.Join(", ", Assignees)}}
         Labels: {{String.Join(", ", Labels.Select(l => l.name))}}
-        Sizes: {{String.Join("\n", from sp in ProjectStoryPoints select $"Project: {sp.ProjectName},  Size: {sp.Size}")}}
+        Sizes: {{String.Join("\n", from sp in ProjectStoryPoints select $"Month, Year: {sp.Month}, {sp.CalendarYear}  Size: {sp.Size}")}}
         Comments:
         {{String.Join("\n\n", from c in Comments select $"Author: {c.author}\nText:\n{c.bodyHTML}")}}
         """;

--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -1,0 +1,61 @@
+﻿namespace Quest2GitHub.Models;
+
+public static class IssueExtensions
+{
+    private static readonly Dictionary<string, int> Months = new ()
+    {
+        ["Jan"] =  1, // 3
+        ["Feb"] =  2, // 3
+        ["Mar"] =  3, // 3
+        ["Apr"] =  4, // 4
+        ["May"] =  5, // 4
+        ["Jun"] =  6, // 4
+        ["Jul"] =  7, // 1
+        ["Aug"] =  8, // 1
+        ["Sep"] =  9, // 1
+        ["Oct"] = 10, // 2
+        ["Nov"] = 11, // 2
+        ["Dec"] = 12  // 2
+    };
+    public static StoryPointSize? LatestStoryPointSize(this GithubIssue issue)
+    {
+        var sizes = from size in issue.ProjectStoryPoints
+                    let month = Months[size.Month]
+                    orderby size.CalendarYear descending,
+                    month descending
+                    select size;
+
+        return sizes.FirstOrDefault();
+    }
+
+    public static int? QuestStoryPoint(this StoryPointSize storyPointSize) =>
+        storyPointSize.Size switch
+        {
+            "🦔 Tiny" => 1,
+            "🐇 Small" => 3,
+            "🐂 Medium" => 5,
+            "🦑 Large" => 8,
+            "🐋 X-Large" => 13,
+            _ => null,
+        };
+
+    public static QuestIteration? ProjectIteration(this StoryPointSize storyPoints, IEnumerable<QuestIteration> iterations)
+    {
+        // Old form: Content\CY_2023\03
+        // New form: Content\Gallium\FY24Q1\07
+
+        var oldPattern = $"""CY_{storyPoints.CalendarYear:D4}\{Months[storyPoints.Month]:D2}""";
+        int fy = ((Months[storyPoints.Month] > 5 ? storyPoints.CalendarYear + 1 : storyPoints.CalendarYear)) % 100;
+        int q = ((((Months[storyPoints.Month]-1) / 3) + 2) % 4) + 1; // Yeah, this is weird. But, it does convert the current month to the FY quarter
+        var newPattern = $"""FY{fy:D2}Q{q:D1}\{Months[storyPoints.Month]:D2}""";
+
+        foreach(var iteration in iterations)
+        {
+            if (iteration.Path.Contains(oldPattern) || iteration.Path.Contains(newPattern))
+            {
+                return iteration;
+            }
+        }
+        return default;
+    }
+}

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -1,10 +1,10 @@
-﻿using DotNetDocs.Tools.GitHubObjects;
-using Microsoft.DotnetOrg.Ospo;
-
-namespace Quest2GitHub.Models;
+﻿namespace Quest2GitHub.Models;
 
 public class QuestWorkItem
 {
+
+    private static bool? linkedGitHubRepo;
+
     /// <summary>
     /// The Work item ID
     /// </summary>
@@ -250,6 +250,8 @@ public class QuestWorkItem
 
     internal async Task<QuestWorkItem?> AddClosingPR(QuestClient azdoClient, string closingPRUrl)
     {
+        if (linkedGitHubRepo is false) return default;
+
         List<JsonPatchDocument> patchDocument = new()
         {
             new JsonPatchDocument
@@ -267,10 +269,12 @@ public class QuestWorkItem
         {
             var jsonDocument = await azdoClient.PatchWorkItem(Id, patchDocument);
             var newItem = QuestWorkItem.WorkItemFromJson(jsonDocument);
+            linkedGitHubRepo = true;
             return newItem;
         } catch (InvalidOperationException ex)
         {
             Console.WriteLine("Can't add closing PR. The GitHub repo is likely not configured as linked in Quest.");
+            linkedGitHubRepo = false;
             return null;
         }
     }

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -2,7 +2,9 @@
 
 public class QuestWorkItem
 {
-
+    // Keep track of failures to upate the closing PR.
+    // For any given run, if the REST call to add a closing PR
+    // fails, stop sending invalid requests.
     private static bool? linkedGitHubRepo;
 
     /// <summary>


### PR DESCRIPTION
When a quest item is created or updated, also write the current value for story points and the most recent iteration project that applies to this GitHub issue.

There's a bit of complexity in the code that updates these fields.

First, there are two formats used in AzureDev Ops for the iteration path. This code supports both formats.
Second, The [docs-maui](https://github.com/dotnet/docs-maui) repo uses a single project for the entire year, with a project field for the iteration. This code supports both formats.

Finally, this PR adds the code to add a relation link for the closing PR. However, that only works correctly if the GitHub repo is configured as a linked repo in Quest. None of the `dotnet` repos are added yet. It may remain optional. Therefore, that update is made in a second REST call so that all other updates happen correctly.
