### PR TITLE
Make updates for new iteration style

### DIFF
--- a/actions/sequester/Quest2GitHub/EnumerateIssues.cs
+++ b/actions/sequester/Quest2GitHub/EnumerateIssues.cs
@@ -34,15 +34,22 @@ public class EnumerateIssues
                   ... on ProjectV2ItemConnection {
                     nodes {
                       ... on ProjectV2Item {
-                        fieldValueByName(name:"Size") {
-                          ... on ProjectV2ItemFieldSingleSelectValue {
-                            name
+                        fieldValues(first:10) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              field {
+                                ... on ProjectV2FieldCommon {
+                                  name
+                                }
+                              }
+                              name
+                            }
                           }
                         }
-                        project {
-                          ... on ProjectV2 {
-                            title
-                          }
+                      }
+                      project {
+                        ... on ProjectV2 {
+                          title
                         }
                       }
                     }

--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -43,11 +43,26 @@ public static class IssueExtensions
     {
         // Old form: Content\CY_2023\03
         // New form: Content\Gallium\FY24Q1\07
+        string month = storyPoints.Month;
+        int calendarYear = storyPoints.CalendarYear;
 
-        var oldPattern = $"""CY_{storyPoints.CalendarYear:D4}\{Months[storyPoints.Month]:D2}""";
-        int fy = ((Months[storyPoints.Month] > 5 ? storyPoints.CalendarYear + 1 : storyPoints.CalendarYear)) % 100;
-        int q = ((((Months[storyPoints.Month]-1) / 3) + 2) % 4) + 1; // Yeah, this is weird. But, it does convert the current month to the FY quarter
-        var newPattern = $"""FY{fy:D2}Q{q:D1}\{Months[storyPoints.Month]:D2}""";
+        return ProjectIteration(month, calendarYear, iterations);
+    }
+
+
+    /// <summary>
+    /// Return the project iteration based on the calendar year and month
+    /// </summary>
+    /// <param name="month">The 3 letter abbreviation for the current month</param>
+    /// <param name="calendarYear">The calendar year</param>
+    /// <param name="iterations">All iterations</param>
+    /// <returns>The current iteration</returns>
+    public static QuestIteration? ProjectIteration(string month, int calendarYear, IEnumerable<QuestIteration> iterations)
+    { 
+        var oldPattern = $"""CY_{calendarYear:D4}\{Months[month]:D2}""";
+        int fy = ((Months[month] > 5 ? calendarYear + 1 : calendarYear)) % 100;
+        int q = ((((Months[month]-1) / 3) + 2) % 4) + 1; // Yeah, this is weird. But, it does convert the current month to the FY quarter
+        var newPattern = $"""FY{fy:D2}Q{q:D1}\{Months[month]:D2}""";
 
         foreach(var iteration in iterations)
         {

--- a/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
@@ -2,19 +2,15 @@
 
 public class QuestIteration
 {
-    private const string PathTeam = "Content";
-    private const string YearPrefix = "CY_";
     public required Guid Id { get; init; }
     public required string Name { get; init; }
     public required string Path { get; init; }
 
-    // Path format is "Content\\CY_YYYY\\MM MMM" (CY is calendar year)
-    // For example: "Content\\CY_2023\\03 Mar"
-    public static string CurrentIterationPath()
+    public static QuestIteration? CurrentIteration(IEnumerable<QuestIteration> iterations)
     {
-        var currentYear = DateTime.Now.ToString("yyyy");
-        var sprintName = DateTime.Now.ToString("MM MMM");
-        return $"Content\\CY_{currentYear}\\{sprintName}";
+        var currentYear = int.Parse(DateTime.Now.ToString("yyyy"));
+        var currentMonth = DateTime.Now.ToString("MMM");
+        return IssueExtensions.ProjectIteration(currentMonth, currentYear, iterations);
     }
 
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -1,6 +1,4 @@
-﻿using DotNetDocs.Tools.GitHubObjects;
-
-namespace Quest2GitHub;
+﻿namespace Quest2GitHub;
 
 /// <summary>
 /// This class manages the top level workflows to synchronize
@@ -77,9 +75,7 @@ public class QuestGitHubService : IDisposable
         {
             _allIterations = await retrieveIterationLabels();
         }
-        var currentIterationPath = QuestIteration.CurrentIterationPath();
-        Console.WriteLine($"Current sprint path: {currentIterationPath}");
-        var currentIteration = _allIterations.Single(sprint => sprint.Path == currentIterationPath);
+        var currentIteration = QuestIteration.CurrentIteration(_allIterations);
 
         var iter = new EnumerateIssues();
 
@@ -134,9 +130,7 @@ public class QuestGitHubService : IDisposable
         {
             _allIterations = await retrieveIterationLabels();
         }
-        var currentIterationPath = QuestIteration.CurrentIterationPath();
-        Console.WriteLine($"Current sprint path: {currentIterationPath}");
-        var currentIteration = _allIterations.Single(sprint => sprint.Path == currentIterationPath);
+        var currentIteration = QuestIteration.CurrentIteration(_allIterations);
 
         //Retrieve the GitHub issue.
         var ghIssue = await RetrieveIssueAsync(gitHubOrganization, gitHubRepository, issueNumber);


### PR DESCRIPTION
The AzDo devops instance changed the iteration path format as of April 1st. Quest stopped working then. The code that retrieved the current iteration by name failed.

After fixing that, noticed that the bulk query wasn't updated in the previous PR. Fixed that while testing this change.