### PR TITLE
Dont unassign when ospo fails

### DIFF
--- a/DotNet.DocsTools/OspoClientServices/OspoClient.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClient.cs
@@ -65,6 +65,10 @@ public sealed class OspoClient : IDisposable
             $"people/links/github/{gitHubLogin}", JsonSerializerOptionsDefaults.Shared);
             return link;
         });
+        if (result.Outcome == OutcomeType.Failure)
+        {
+            throw new InvalidOperationException("OSPO REST API failure. Check access token rights");
+        }
 
         return result.Result;
     }
@@ -86,6 +90,12 @@ public sealed class OspoClient : IDisposable
             linkSet.Initialize();
             return linkSet;
         });
+
+        if (result.Outcome == OutcomeType.Failure)
+        {
+            throw new InvalidOperationException("OSPO REST API failure. Check access token rights");
+        }
+
         _allLinks = result.Result;
         return result.Result;
     }

--- a/DotNet.DocsTools/OspoClientServices/OspoClient.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClient.cs
@@ -50,7 +50,7 @@ public sealed class OspoClient : IDisposable
 
     public async Task<OspoLink?> GetAsync(string gitHubLogin)
     {
-        if (_useAllCache)
+        if ((_useAllCache) || (_allLinks is not null))
         {
             _allLinks = _allLinks ?? await GetAllAsync();
             return _allLinks.LinkByLogin.GetValueOrDefault(gitHubLogin); 

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -75,6 +75,7 @@ internal class Program
         }
         catch (Exception ex)
         {
+            Console.Error.WriteLine($"::  -- {ex.Message} -- ");
             Console.Error.WriteLine(ex.ToString());
             return 1;
         }
@@ -98,6 +99,6 @@ internal class Program
                 options.AzureDevOps.AreaPath,
                 options.ImportTriggerLabel,
                 options.ImportedLabel,
-                !bulkImport);
+                bulkImport);
     }
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -69,6 +69,8 @@ public class QuestGitHubService : IDisposable
     /// <returns></returns>
     public async Task ProcessIssues(string organization, string repository, int duration, bool dryRun)
     {
+        // Trigger the OSPO bulk import before making any edits to any issue:
+        await _ospoClient.GetAllAsync();
         if ((_importTriggerLabel is null) || (_importedLabel is null))
             await retrieveLabelIDs(organization, repository);
         if (_allIterations is null)
@@ -124,6 +126,9 @@ public class QuestGitHubService : IDisposable
     /// <returns>A task representing the current operation</returns>
     public async Task ProcessIssue(string gitHubOrganization, string gitHubRepository, int issueNumber)
     {
+        // Trigger the OSPO bulk import before making any edits to any issue:
+        await _ospoClient.GetAllAsync();
+
         if ((_importTriggerLabel == null) || (_importedLabel == null))
             await retrieveLabelIDs(gitHubOrganization, gitHubRepository);
         if (_allIterations is null)


### PR DESCRIPTION
When an OSPO token expires, or otherwise becomes invalid, the Quest import unassigns all work items. That's bad.

This PR checks that update first, and then if it fails, the program exits.
