### PR TITLE
Account for reference links

### DIFF
--- a/cleanrepo/CleanRepo/Program.cs
+++ b/cleanrepo/CleanRepo/Program.cs
@@ -450,7 +450,8 @@ static class Program
 
         List<string> regexes = new List<string>()
             {
-                @"\]\(<?(/" + urlBasePath + @"/([^\)\s]*)>?)\)",                                    // [link text](/docsetName/some other text)
+                @"\]\(<?(/" + urlBasePath + @"/([^\)\s]*)>?)\)",                                    // [link text](/basepath/some other text)
+                @"\]:\s(/" + urlBasePath + @"/([^\s]*))",                                           // [ref link]: /basepath/some other text
                 "<img[^>]*?src[ ]*=[ ]*\"(/" + urlBasePath + "/([^>]*?.(png|gif|jpg|svg)))[ ]*\"",  // <img src="/azure/mydocs/media/pic3.png">
                 @"\[.*\]:[ ]*(/" + urlBasePath + @"/(.*\.(png|gif|jpg|svg)))",                      // [0]: /azure/mydocs/media/pic1.png
                 @"imageSrc:[ ]*(/" + urlBasePath + @"/([^:]*\.(png|gif|jpg|svg)))",                 // imageSrc: /azure/mydocs/media/pic1.png

--- a/cleanrepo/CleanRepo/Program.cs
+++ b/cleanrepo/CleanRepo/Program.cs
@@ -1203,57 +1203,73 @@ static class Program
 
         foreach (var linkedFile in linkedFiles)
         {
-            string linkRegEx = linkingFile.Extension.ToLower() == ".yml" ?
-                    @"href:(.*?" + linkedFile.Name + ")" :
-                    @"\]\(<?(([^\)])*?" + linkedFile.Name + @")";
-
-            // For each link that contains the file name...
-            // Regex ignores case.
-            foreach (Match match in Regex.Matches(fileContents, linkRegEx, RegexOptions.IgnoreCase))
+            List<string> mdRegexes = new List<string>()
             {
-                // Get the file-relative path to the linked file.
-                string relativePath = match.Groups[1].Value.Trim();
+                @"\]\(<?(([^\)])*?" + linkedFile.Name + @")",
+                @"\]:\s" + linkedFile.Name
+            };
 
-                // Remove any quotation marks
-                relativePath = relativePath.Replace("\"", "");
+            string ymlRegex = @"href:(.*?" + linkedFile.Name + ")";
 
-                if (relativePath != null)
+            if (linkingFile.Extension.ToLower() == ".yml")
+                FindMatches(linkingFile, filesToKeep, fileContents, linkedFile, ymlRegex);
+            else // Markdown file.
+            {
+                foreach (var mdRegex in mdRegexes)
                 {
-                    string fullPath;
-                    try
-                    {
-                        // Construct the full path to the referenced file
-                        fullPath = Path.Combine(linkingFile.DirectoryName, relativePath);
-                    }
-                    catch (ArgumentException e)
-                    {
-                        Console.WriteLine($"\nCaught exception while constructing full path " +
-                            $"for '{relativePath}' in '{linkingFile.FullName}': {e.Message}");
-                        throw;
-                    }
+                    FindMatches(linkingFile, filesToKeep, fileContents, linkedFile, mdRegex);
+                }
+            }
+        }
+    }
 
-                    // This cleans up the path by replacing forward slashes with back slashes, removing extra dots, etc.
-                    fullPath = Path.GetFullPath(fullPath);
-                    if (fullPath != null)
+    private static void FindMatches(FileInfo linkingFile, Dictionary<string, int> filesToKeep, string fileContents, FileInfo linkedFile, string linkRegEx)
+    {
+        // For each link that contains the file name...
+        foreach (Match match in Regex.Matches(fileContents, linkRegEx, RegexOptions.IgnoreCase))
+        {
+            // Get the file-relative path to the linked file.
+            string relativePath = match.Groups[1].Value.Trim();
+
+            // Remove any quotation marks
+            relativePath = relativePath.Replace("\"", "");
+
+            if (relativePath != null)
+            {
+                string fullPath;
+                try
+                {
+                    // Construct the full path to the referenced file
+                    fullPath = Path.Combine(linkingFile.DirectoryName, relativePath);
+                }
+                catch (ArgumentException e)
+                {
+                    Console.WriteLine($"\nCaught exception while constructing full path " +
+                        $"for '{relativePath}' in '{linkingFile.FullName}': {e.Message}");
+                    throw;
+                }
+
+                // This cleans up the path by replacing forward slashes with back slashes, removing extra dots, etc.
+                fullPath = Path.GetFullPath(fullPath);
+                if (fullPath != null)
+                {
+                    // See if our constructed path matches the actual file we think it is; ignores case.
+                    if (String.Compare(fullPath, linkedFile.FullName, true) == 0)
                     {
-                        // See if our constructed path matches the actual file we think it is; ignores case.
-                        if (String.Compare(fullPath, linkedFile.FullName, true) == 0)
+                        // File is linked from another file.
+                        if (filesToKeep.ContainsKey(linkedFile.FullName))
                         {
-                            // File is linked from another file.
-                            if (filesToKeep.ContainsKey(linkedFile.FullName))
-                            {
-                                // Increment the count of links to this file.
-                                filesToKeep[linkedFile.FullName]++;
-                            }
-                            else
-                            {
-                                filesToKeep.Add(linkedFile.FullName, 1);
-                            }
+                            // Increment the count of links to this file.
+                            filesToKeep[linkedFile.FullName]++;
                         }
                         else
                         {
-                            // This link did not match the full file name.
+                            filesToKeep.Add(linkedFile.FullName, 1);
                         }
+                    }
+                    else
+                    {
+                        // This link did not match the full file name.
                     }
                 }
             }

--- a/cleanrepo/CleanRepo/Repo.cs
+++ b/cleanrepo/CleanRepo/Repo.cs
@@ -733,12 +733,12 @@ class DocFxRepo
             string text = File.ReadAllText(linkingFile.FullName);
 
             if (linkingFile.Extension.ToLower() == ".yml")
-                FindLinks(ymlRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
+                FindAndReplaceLinks(ymlRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
             else // Markdown file.
             {
                 foreach (var mdRegex in mdRegexes)
                 {
-                    FindLinks(mdRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
+                    FindAndReplaceLinks(mdRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
 
                 }
             }
@@ -748,7 +748,7 @@ class DocFxRepo
         }
     }
 
-    private void FindLinks(string regexPattern, Dictionary<string, Redirect> redirectLookup, FileInfo linkingFile, ref bool foundOldLink, StringBuilder output, ref string text)
+    private void FindAndReplaceLinks(string regexPattern, Dictionary<string, Redirect> redirectLookup, FileInfo linkingFile, ref bool foundOldLink, StringBuilder output, ref string text)
     {
         // For each link in the file...
         // Regex ignores case.

--- a/cleanrepo/CleanRepo/Repo.cs
+++ b/cleanrepo/CleanRepo/Repo.cs
@@ -813,13 +813,19 @@ class DocFxRepo
                     if (!String.IsNullOrEmpty(match.Groups[2].Value))
                         redirectURL = redirectURL + match.Groups[2].Value;
 
-                    output.AppendLine($"REPLACING '({relativePath})' with '({redirectURL})'.");
+                    output.AppendLine($"REPLACING '{relativePath}' with '{redirectURL}'.");
 
                     // Replace the link.
                     if (linkingFile.Extension.ToLower() == ".md")
-                        text = text.Replace(match.Groups[0].Value, $"]({redirectURL})");
+                    {
+                        if (regexPattern.StartsWith(@"\]:"))
+                            text = text.Replace(match.Groups[0].Value, $"]: {redirectURL}");
+                        else
+                            text = text.Replace(match.Groups[0].Value, $"]({redirectURL})");
+                    }
                     else // .yml file
                         text = text.Replace(match.Groups[0].Value, $"href: {redirectURL}");
+
                     File.WriteAllText(linkingFile.FullName, text);
                 }
             }

--- a/cleanrepo/CleanRepo/Repo.cs
+++ b/cleanrepo/CleanRepo/Repo.cs
@@ -715,6 +715,15 @@ class DocFxRepo
         Dictionary<string, Redirect> redirectLookup =
             Enumerable.ToDictionary(redirects, r => r.source_path_absolute, StringComparer.InvariantCultureIgnoreCase);
 
+        List<string> mdRegexes = new List<string>()
+            {
+                @"\]\(<?([^\)]*\.md)(#[\w-]+)?>?\)",
+                @"\]:\s(.*\.md)(#[\w-]+)?"
+            };
+
+        // Matches link with optional #bookmark on the end.
+        string ymlRegex = @"href:(.*\.md)(#[\w-]+)?";
+
         // For each file...
         foreach (var linkingFile in linkingFiles)
         {
@@ -723,88 +732,97 @@ class DocFxRepo
 
             string text = File.ReadAllText(linkingFile.FullName);
 
-            // Matches link with optional #bookmark on the end.
-            string linkRegEx = linkingFile.Extension.ToLower() == ".yml" ?
-                @"href:(.*\.md)(#[\w-]+)?" :
-                @"\]\(<?([^\)]*\.md)(#[\w-]+)?>?\)";
-
-            // For each link in the file...
-            // Regex ignores case.
-            foreach (Match match in Regex.Matches(text, linkRegEx, RegexOptions.IgnoreCase))
+            if (linkingFile.Extension.ToLower() == ".yml")
+                FindLinks(ymlRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
+            else // Markdown file.
             {
-                // Get the file-relative path to the linked file.
-                string relativePath = match.Groups[1].Value.Trim();
-
-                if (relativePath.StartsWith("http"))
+                foreach (var mdRegex in mdRegexes)
                 {
-                    // This could be an absolute URL to a file in the repo, so check.
-                    string httpRegex = @"https?:\/\/learn.microsoft.com\/([A-z][A-z]-[A-z][A-z]\/)?" + UrlBasePath + @"\/";
-                    var httpMatch = Regex.Match(relativePath, httpRegex, RegexOptions.IgnoreCase);
+                    FindLinks(mdRegex, redirectLookup, linkingFile, ref foundOldLink, output, ref text);
 
-                    if (!httpMatch.Success)
-                    {
-                        // The file is in a different repo, so ignore it.
-                        continue;
-                    }
-
-                    // Chop off the https://learn.microsoft.com/BasePathUrl/ part of the path.
-                    relativePath = relativePath.Substring(httpMatch.Value.Length);
-                }
-
-                // Remove any quotation marks
-                relativePath = relativePath.Replace("\"", "");
-
-                string fullPath = null;
-                try
-                {
-                    // Construct the full path to the linked file.
-                    fullPath = Path.Combine(linkingFile.DirectoryName, relativePath);
-                }
-                catch (ArgumentException)
-                {
-                    Console.WriteLine($"Ignoring the link {relativePath} due to possibly invalid format.\n");
-                    continue;
-                }
-
-                // Clean up the path by replacing forward slashes with back slashes, removing extra dots, etc.
-                try
-                {
-                    fullPath = Path.GetFullPath(fullPath);
-                }
-                catch (NotSupportedException)
-                {
-                    //Console.WriteLine($"Found a possibly malformed link '{match.Groups[0].Value}' in '{linkingFile.FullName}'.\n");
-                    break;
-                }
-
-                if (fullPath != null)
-                {
-                    // See if our constructed path matches a source file in the dictionary of redirects.
-                    if (redirectLookup.ContainsKey(fullPath))
-                    {
-                        foundOldLink = true;
-                        output.AppendLine($"'{relativePath}'");
-
-                        string redirectURL = redirectLookup[fullPath].redirect_url;
-
-                        // Add the bookmark back on, in case it applies to the new target.
-                        if (!String.IsNullOrEmpty(match.Groups[2].Value))
-                            redirectURL = redirectURL + match.Groups[2].Value;
-
-                        output.AppendLine($"REPLACING '({relativePath})' with '({redirectURL})'.");
-
-                        // Replace the link.
-                        if (linkingFile.Extension.ToLower() == ".md")
-                            text = text.Replace(match.Groups[0].Value, $"]({redirectURL})");
-                        else // .yml file
-                            text = text.Replace(match.Groups[0].Value, $"href: {redirectURL}");
-                        File.WriteAllText(linkingFile.FullName, text);
-                    }
                 }
             }
 
             if (foundOldLink)
                 Console.WriteLine(output.ToString());
+        }
+    }
+
+    private void FindLinks(string regexPattern, Dictionary<string, Redirect> redirectLookup, FileInfo linkingFile, ref bool foundOldLink, StringBuilder output, ref string text)
+    {
+        // For each link in the file...
+        // Regex ignores case.
+        foreach (Match match in Regex.Matches(text, regexPattern, RegexOptions.IgnoreCase))
+        {
+            // Get the file-relative path to the linked file.
+            string relativePath = match.Groups[1].Value.Trim();
+
+            if (relativePath.StartsWith("http"))
+            {
+                // This could be an absolute URL to a file in the repo, so check.
+                string httpRegex = @"https?:\/\/learn.microsoft.com\/([A-z][A-z]-[A-z][A-z]\/)?" + UrlBasePath + @"\/";
+                var httpMatch = Regex.Match(relativePath, httpRegex, RegexOptions.IgnoreCase);
+
+                if (!httpMatch.Success)
+                {
+                    // The file is in a different repo, so ignore it.
+                    continue;
+                }
+
+                // Chop off the https://learn.microsoft.com/BasePathUrl/ part of the path.
+                relativePath = relativePath.Substring(httpMatch.Value.Length);
+            }
+
+            // Remove any quotation marks
+            relativePath = relativePath.Replace("\"", "");
+
+            string fullPath = null;
+            try
+            {
+                // Construct the full path to the linked file.
+                fullPath = Path.Combine(linkingFile.DirectoryName, relativePath);
+            }
+            catch (ArgumentException)
+            {
+                Console.WriteLine($"Ignoring the link {relativePath} due to possibly invalid format.\n");
+                continue;
+            }
+
+            // Clean up the path by replacing forward slashes with back slashes, removing extra dots, etc.
+            try
+            {
+                fullPath = Path.GetFullPath(fullPath);
+            }
+            catch (NotSupportedException)
+            {
+                //Console.WriteLine($"Found a possibly malformed link '{match.Groups[0].Value}' in '{linkingFile.FullName}'.\n");
+                break;
+            }
+
+            if (fullPath != null)
+            {
+                // See if our constructed path matches a source file in the dictionary of redirects.
+                if (redirectLookup.ContainsKey(fullPath))
+                {
+                    foundOldLink = true;
+                    output.AppendLine($"'{relativePath}'");
+
+                    string redirectURL = redirectLookup[fullPath].redirect_url;
+
+                    // Add the bookmark back on, in case it applies to the new target.
+                    if (!String.IsNullOrEmpty(match.Groups[2].Value))
+                        redirectURL = redirectURL + match.Groups[2].Value;
+
+                    output.AppendLine($"REPLACING '({relativePath})' with '({redirectURL})'.");
+
+                    // Replace the link.
+                    if (linkingFile.Extension.ToLower() == ".md")
+                        text = text.Replace(match.Groups[0].Value, $"]({redirectURL})");
+                    else // .yml file
+                        text = text.Replace(match.Groups[0].Value, $"href: {redirectURL}");
+                    File.WriteAllText(linkingFile.FullName, text);
+                }
+            }
         }
     }
     #endregion


### PR DESCRIPTION
Fixes #220 

Adds an extra regex pattern to check for Markdown files. The rest of the changes just refactored the meat of the loops into helper methods.