### PR TITLE
where once was null, use string.IsNullOrWhiteSpace

### DIFF
--- a/WhatsNew.Cli/Program.cs
+++ b/WhatsNew.Cli/Program.cs
@@ -20,6 +20,7 @@ public class Program
     /// <param name="savedir">An absolute directory path to which the generated Markdown file should be written.</param>
     /// <param name="reporoot">The path to the repository root folder.</param>
     /// <param name="localconfig">An absolute file path to a local JSON configuration file. For local testing only.</param>
+    /// <param name="savefile">The path to the single markdown file for repos that use one markdown file.</param>
     /// <returns>The <see cref="Task"/> generating the what's new page.</returns>
     public static async Task Main(
         string? startdate, string? enddate, string owner, string repo,
@@ -50,7 +51,7 @@ public class Program
         var pageGenService = new PageGenerationService(whatsNewConfig);
 
         await pageGenService.WriteMarkdownFile(savefile);
-         if (savefile is null)
+         if (string.IsNullOrWhiteSpace(savefile))
         {
             var tocService = new TocUpdateService(whatsNewConfig);
             await tocService.UpdateWhatsNewToc();

--- a/WhatsNew.Infrastructure/Services/PageGenerationService.cs
+++ b/WhatsNew.Infrastructure/Services/PageGenerationService.cs
@@ -42,7 +42,7 @@ public class PageGenerationService
     {
         await ProcessPullRequests();
 
-        if (existingMarkdownFile is null)
+        if (string.IsNullOrWhiteSpace(existingMarkdownFile))
         {
             var filePath = GetMarkdownFilePath();
             await using TextWriter stream = new StreamWriter(filePath);


### PR DESCRIPTION
The YML action file passes an empty string rather than null for missing arguments.