### PR TITLE
Fix slash left at start of path

### DIFF
--- a/snippets5000/Snippets5000/PullRequestProcessor.cs
+++ b/snippets5000/Snippets5000/PullRequestProcessor.cs
@@ -228,5 +228,5 @@ internal class PullRequestProcessor
     }
 
     static string TransformPathToUnix(string repoRoot, string filePath) =>
-        filePath.Substring(repoRoot.Length).Replace("\\", "/");
+        filePath.Substring(repoRoot.Length + 1).Replace("\\", "/");
 }

--- a/snippets5000/Snippets5000/PullRequestSimulationsHelpers/ExpectedResult.cs
+++ b/snippets5000/Snippets5000/PullRequestSimulationsHelpers/ExpectedResult.cs
@@ -16,6 +16,11 @@ public readonly struct ExpectedResult
     /// </summary>
     public string DiscoveredProject { get; init; }
 
+    /// <summary>
+    /// Creates a new result with the specified code and project.
+    /// </summary>
+    /// <param name="resultCode">The result code.</param>
+    /// <param name="discoveredProject">The path to the project.</param>
     public ExpectedResult(int resultCode, string discoveredProject)
     {
         ResultCode = resultCode;


### PR DESCRIPTION
During compile, the path was resolving to the root of the repo because of a `/` at the start of the file path.