### PR TITLE
Add a new GitHub Action: ".NET version upgrader"

### DIFF
--- a/actions/dotnet-version-updater/action.yml
+++ b/actions/dotnet-version-updater/action.yml
@@ -35,4 +35,4 @@ runs:
       run: |
         $support = '${{ inputs.support }}'
         $projects = ${{ steps.dotnet-version-sweeper.outputs.upgrade-projects }}
-        .\upgrade-projects.ps1 $support $projects
+        ./upgrade-projects.ps1 $support $projects

--- a/actions/dotnet-version-updater/action.yml
+++ b/actions/dotnet-version-updater/action.yml
@@ -1,0 +1,38 @@
+name: '.NET version upgrader'
+description: 'A GitHub Action that relies on the .NET version sweeper to upgrade projects to the latest .NET version.'
+branding:
+  icon: 'git-pull-request'
+  color: 'purple'
+inputs:
+  support:
+      description: "The support level to target (STS, LTS, or Preview)."
+      required: false
+      default: "STS"
+runs:
+  using: "composite"
+  steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+
+    # Start the .NET version sweeper, scan projects/slns for non-LTS (or STS) versions
+    - name: .NET version sweeper
+      id: dotnet-version-sweeper
+      uses: dotnet/versionsweeper@main
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          owner: ${{ github.repository_owner }}
+          name: ${{ github.repository }}
+          branch: ${{ github.ref }}
+
+    # Call the upgrade projects script, passing in the list of projects to upgrade
+    - id: upgrade-projects
+      if: steps.dotnet-version-sweeper.outputs.has-remaining-work == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT: '1' # opt-out of upgrade-assistant telemetry
+      shell: pwsh
+      run: |
+        $support = '${{ inputs.support }}'
+        $projects = ${{ steps.dotnet-version-sweeper.outputs.upgrade-projects }}
+        .\upgrade-projects.ps1 $support $projects

--- a/actions/dotnet-version-updater/upgrade-projects.ps1
+++ b/actions/dotnet-version-updater/upgrade-projects.ps1
@@ -1,0 +1,52 @@
+$support = $args[0]         # STS, LTS, or Preview
+$projectsJson = $args[1]    # JSON string of projects to upgrade
+
+Write-Host "Upgrading projects to $support versions"
+
+# Convert JSON string to array of strings
+$projects = ConvertFrom-Json $projectsJson
+
+Write-Host "Found $($projects.Length) projects to upgrade"
+
+# Install .NET Upgrade Assistant global tool
+dotnet tool install --global upgrade-assistant
+
+# Iterate all upgrade projects
+foreach ($projectDir in $projects) {
+    Write-Host "Attempting to upgrade project: $projectDir"
+
+    # Create a new branch
+    $branchName = $projectDir -replace '[^A-Za-z0-9._-]', '-'
+    $branch = "upgrade/$branchName"
+    git checkout -b $branch
+
+    upgrade-assistant upgrade "$projectDir" `
+        --non-interactive `
+        --operation Inplace `
+        -t $support
+
+    # Attempt the upgrade using upgrade-assistant
+    if ($LASTEXITCODE -eq 0) {
+        # Commit the changes
+        git add .
+        git commit -m ".NET Version Sweeper: Upgraded $projectDir"
+
+        # Push the branch to the repository
+        git push origin $branch
+
+        # Create a pull request
+        gh pr create `
+            --base main `
+            --head $branch `
+            --title "[$support] Upgrade $projectDir" `
+            --body "Automated pull request to upgrade the target framework moniker `
+            (TFM) of $projectDir to .NET $support."
+    }
+    else {
+        Write-Host "Unable to upgrade project: $projectDir"
+
+        # Delete the branch if the upgrade fails
+        git checkout main
+        git branch -D $branch
+    }
+}

--- a/actions/dotnet-version-updater/upgrade-projects.ps1
+++ b/actions/dotnet-version-updater/upgrade-projects.ps1
@@ -2,31 +2,76 @@ $support = $args[0]         # STS, LTS, or Preview
 $projectsJson = $args[1]    # JSON string of projects to upgrade
 
 Write-Host "Upgrading projects to $support versions"
+Write-Host ""
 
 # Convert JSON string to array of strings
 $projects = ConvertFrom-Json $projectsJson
 
-Write-Host "Found $($projects.Length) projects to upgrade"
+Write-Host "Parsed $($projects.Length) projects to upgrade"
+Write-Host ""
 
 # Install .NET Upgrade Assistant global tool
 dotnet tool install --global upgrade-assistant
 
+# Get the git repository directory
+$gitRepoDir = (git rev-parse --show-toplevel)
+
+# Create an array of projects that to track failure attempts
+$failedProjects = @()
+
 # Iterate all upgrade projects
 foreach ($projectDir in $projects) {
     Write-Host "Attempting to upgrade project: $projectDir"
+    Write-Host ""
+
+    # Remove the git repository directory from the project directory
+    $relativePath = $projectDir.Replace($gitRepoDir, "")
+
+    # Remove invalid characters from the branch name, then remove leading hyphen
+    $branchName = $relativePath -replace '[^A-Za-z0-9._-]', '-'
+    $branchName = $branchName -replace '^[-]+', ''
+
+    # Format the branch name
+    $branch = "auto-upgrade/$branchName"
 
     # Create a new branch
-    $branchName = $projectDir -replace '[^A-Za-z0-9._-]', '-'
-    $branch = "upgrade/$branchName"
     git checkout -b $branch
 
-    upgrade-assistant upgrade "$projectDir" `
+    # Normalize the project directory
+    $projectDir = [IO.Path]::GetFullPath($projectDir)
+
+    # Capture all output from the upgrade-assistant command
+    $output = upgrade-assistant upgrade "$projectDir" `
         --non-interactive `
         --operation Inplace `
-        -t $support
+        -t $support `
+        2>&1
 
-    # Attempt the upgrade using upgrade-assistant
-    if ($LASTEXITCODE -eq 0) {
+    # Check if the exit code is 0 (success), or if there is output from a failure
+    if ($LASTEXITCODE -eq 0 -and -not ($output -match "Exception")) {
+
+        Write-Host $output
+        Write-Host ""
+
+        # Check for changes, report the exit code
+        git diff --exit-code
+
+        # If there aren't any, delete the 
+        # branch and continue to the next project
+        if ($LASTEXITCODE -ne 0) {
+            $failedProjects += $projectDir
+
+            Write-Host "No changes detected for project: $projectDir"
+            Write-Host ""
+
+            # Delete the branch if there aren't any changes
+            git checkout main
+            git branch -D $branch
+            Write-Host ""
+
+            continue
+        }
+
         # Commit the changes
         git add .
         git commit -m ".NET Version Sweeper: Upgraded $projectDir"
@@ -34,19 +79,44 @@ foreach ($projectDir in $projects) {
         # Push the branch to the repository
         git push origin $branch
 
+        # Format the pull request message
+        $pullRequestMessage = "⚡ This is an automated pull request (powered by the 
+            [.NET Versioon Sweeper](https://github.com/dotnet/versionsweeper) and
+            the [.NET Upgrade Assistant](https://github.com/dotnet/upgrade-assistant)]) 
+            to _upgrade_ the **target framework moniker (TFM)** for the '$projectDir' 
+            project to the $support version. For more information, see 
+            [.NET Support Policy](https://dotnet.microsoft.com/platform/support/policy)."
+
         # Create a pull request
         gh pr create `
             --base main `
             --head $branch `
             --title "[$support] Upgrade $projectDir" `
-            --body "Automated pull request to upgrade the target framework moniker `
-            (TFM) of $projectDir to .NET $support."
+            --body $pullRequestMessage
     }
     else {
+        $failedProjects += $projectDir
+
         Write-Host "Unable to upgrade project: $projectDir"
+        Write-Host ""
+
+        # Write the output as a warning
+        Write-Warning -Message ([String]::Join("`n", $output))
+        Write-Host ""
 
         # Delete the branch if the upgrade fails
         git checkout main
         git branch -D $branch
+        Write-Host ""
+    }
+}
+
+# If there are any failed projects, log them
+if ($failedProjects.Length -gt 0) {
+    Write-Host "Failed to upgrade $($failedProjects.Length) projects:"
+    Write-Host ""
+
+    foreach ($failedProject in $failedProjects) {
+        Write-Host $failedProject
     }
 }


### PR DESCRIPTION
This is a new GitHub Action that will call the `upgrade-assistant` given outputs from the .NET Version Sweeper. It's a composite, that relies on `dotnet/versionsweeper` and a custom PowerShell script.

Fixes #246