### PR TITLE
Tighten up status checker's pull request update logging

### DIFF
--- a/actions/status-checker/src/pull-updater.ts
+++ b/actions/status-checker/src/pull-updater.ts
@@ -30,8 +30,13 @@ export async function tryUpdatePullRequestBody(token: string) {
       return;
     } else {
       try {
+        console.log("::group::Pull request JSON body");
         console.log(JSON.stringify(pullRequest, undefined, 2));
-      } catch {}
+        console.log("::endgroup::");
+      }
+      catch {
+        console.log("::endgroup::");
+      }
     }
 
     allFiles = [...pullRequest.files.edges];
@@ -79,8 +84,9 @@ export async function tryUpdatePullRequestBody(token: string) {
       updatedBody = appendTable(pullRequest.body, markdownTable);
     }
 
-    console.log("Proposed PR body:");
+    console.log("::group::Proposed PR body");
     console.log(updatedBody);
+    console.log("::endgroup::");
 
     const octokit = getOctokit(token);
     const response = await octokit.rest.pulls.update({


### PR DESCRIPTION
This adds groups to the PR JSON dump and the proposed PR body preview. This way they're collapsible regions which makes seeing the other errors the status checker reports most likely visible. Otherwise you have to scroll up a few pages when you're looking at the action report.