### PR TITLE
Flow `GITHUB_TOKEN` as an action.yml `input`

### DIFF
--- a/actions/dotnet-version-updater/action.yml
+++ b/actions/dotnet-version-updater/action.yml
@@ -1,36 +1,39 @@
-name: '.NET version upgrader'
-description: 'A GitHub Action that relies on the .NET version sweeper to upgrade projects to the latest .NET version.'
+name: ".NET version upgrader"
+description: "A GitHub Action that relies on the .NET version sweeper to upgrade projects to the latest .NET version."
 branding:
-  icon: 'git-pull-request'
-  color: 'purple'
+  icon: "git-pull-request"
+  color: "purple"
 inputs:
   support:
-      description: "The support level to target (STS, LTS, or Preview)."
-      required: false
-      default: "STS"
+    description: "The support level to target (STS, LTS, or Preview)."
+    required: false
+    default: "STS"
+  token:
+    description: "The GitHub token to use for authentication."
+    required: true
 runs:
   using: "composite"
   steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
 
-    # Start the .NET version sweeper, scan projects/slns for non-LTS (or STS) versions
+    # Start the .NET version sweeper, scan project(s)/sln(s) for non-LTS (or STS) versions
     - name: .NET version sweeper
       id: dotnet-version-sweeper
       uses: dotnet/versionsweeper@main
       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ inputs.token }}
       with:
-          owner: ${{ github.repository_owner }}
-          name: ${{ github.repository }}
-          branch: ${{ github.ref }}
+        owner: ${{ github.repository_owner }}
+        name: ${{ github.repository }}
+        branch: ${{ github.ref }}
 
     # Call the upgrade projects script, passing in the list of projects to upgrade
     - id: upgrade-projects
       if: steps.dotnet-version-sweeper.outputs.has-remaining-work == 'true'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT: '1' # opt-out of upgrade-assistant telemetry
+        GITHUB_TOKEN: ${{ inputs.token }}
+        DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT: "1" # opt-out of upgrade-assistant telemetry
       shell: pwsh
       run: |
         $support = '${{ inputs.support }}'


### PR DESCRIPTION
In this PR:

- The `${{ secrets.* }}` expressions don't work within _action.yml_ files.
- Instead, we must flow the `GITHUB_TOKEN` through as an `input`.

Fixes #264