### PR TITLE
Clarify the use of `navigationOptions`

### DIFF
--- a/WhatsNew.Cli/README.md
+++ b/WhatsNew.Cli/README.md
@@ -93,7 +93,7 @@ dotnet WhatsNew.Cli.dll --owner dotnet --repo docs --startdate 7/1/2020 --enddat
 | `startdate` | A range start date in a valid format. For example, "yyyy-MM-dd" or "MM/dd/yyyy". Any format accepted by [`DateTime.Parse`](https://learn.microsoft.com/dotnet/api/system.datetime.parse)` is accepted. | `--startdate 7/1/2020` |
 | `enddate`  | A range end date in a valid format. For example, "yyyy-MM-dd" or "MM/dd/yyyy". Any format accepted by [`DateTime.Parse`](https://learn.microsoft.com/dotnet/api/system.datetime.parse)` is accepted. | `--enddate 7/15/2020` |
 | `savedir`   | An absolute directory path to which the generated Markdown file should be written. | `--savedir C:\whatsnew` |
-| `savefile`  | The path to an existing file that should be modified by the tool. | `--savefile ./docs/ide/whats-new-visual-studio-docs.md` |
+| `savefile`  | The path to an existing file that should be modified by the tool. If this option isn't supplied, the tool uses the [Navigation options](#navigationoptions-properties) to determine any index and TOC file that should be updated. | `--savefile ./docs/ide/whats-new-visual-studio-docs.md` |
 | `reporoot`   | An absolute directory path to the root folder of your repository. Default is "./" | `--reporoot C:\source\dotnet\docs`|
 | `localconfig` | An absolute file path for a local JSON configuration file. Intended for local testing only. | `--localconfig C:\configs\.whatsnew.json` |
 
@@ -141,7 +141,9 @@ The following properties are supported in the JSON configuration file.
 
 ### `navigationOptions` properties
 
-These options apply in the 2.0 release of the What's New tool. The 2.0 release will update nodes in a TOC and an index file in addition to creating the What's New file. That requires config options for how many What's New files to keep publishing, and where to find the YML nodes to update.
+These options apply in the 2.0 release of the What's New tool. Furthermore, these options are only used when the `--savefile` option isn't included on the command line. When the safe tile isn't included, the tool assumes separate files are created for each month. In addition to updating the files, the tool updates the associated TOC nodes, and any index nodes.
+
+The 2.0 release will update nodes in a TOC and an index file in addition to creating the What's New file. That requires config options for how many What's New files to keep publishing, and where to find the YML nodes to update.
 
 | Property                  | Description | Example |
 | ------------------------- | ----------- | ------- |

--- a/actions/sequester/README.md
+++ b/actions/sequester/README.md
@@ -19,12 +19,11 @@ To install the GitHub actions:
    - In the root folder of your repo, create a config file that contains the keys shown [later in this document](#configure-consuming-github-action-workflow). In most cases, you'll modify the Azure DevOps area path, and trigger labels.
 1. ***Add the `quest.yml` and `quest-bulk.yml` action workflow files***
    - For an example, see the [`dotnet/docs` installation](https://github.com/dotnet/docs/blob/main/.github/workflows/quest.yml). You'll likely need to change the checks on the labels.
-1. ***Add secrets for Azure Dev Ops and Microsoft Open Source Programs Office***
-   - You'll need to add two secret tokens to access the OSPO REST APIs and Quest Azure DevOps APIs.
+1. ***Add secrets for Azure Dev Ops and Microsoft Open Source Programs Office*** You'll need to add three secret tokens to access the OSPO REST APIs and Quest Azure DevOps APIs.
    - *OSPO_KEY*: Generate a PAT [here](https://ossmsft.visualstudio.com/_usersSettings/tokens). UserProfile: Read is the only access needed.
-   - *QUEST_KEY*: Generate a PAT [here](https://dev.azure.com/msft-skilling/_usersSettings/tokens). WorkItems: Read/Write and Project & Team: Read/Write access are needed.
-     Identity: Read is also needed.
-1. Start applying labels.
+   - *SEQUESTER_APPID*: This is the app ID for the Sequester Action. You get this from one of the App administrators (Bill or Immo).
+   - *SEQUESTER_PRIVATEKEY*: This is the private key to authorize sequester. You get this from one of the App administrators (Bill or Immo).
+1. ***Start applying labels***
    - Add the trigger label to any issue, and it will be imported into Quest.
 
 > **Note**: You may need to configure GitHub Actions in your repository settings. For more information, see [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).


### PR DESCRIPTION
The navigation options node in the config is used only when the `--savefile` command line argument isn't specified.

Repos that use a single what's new file, where the newest section is added and the oldest section is removed, don't use the navigation options, but specify the `--savefile` on the command line.