### PR TITLE
use configured area order

### DIFF
--- a/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
+++ b/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
@@ -99,7 +99,7 @@ public class PullRequestsMergedInSprint
         while (hasMore)
         {
             queryText.variables["end_cursor"] = cursor!;
-            Console.WriteLine($"Sending query:\n{queryText}\n\n");
+            Console.WriteLine($"Sending query:\n{queryText.ToJsonText()}\n\n");
             var jsonData = await client.PostGraphQLRequestAsync(queryText);
 
             var searchNodes = jsonData.GetProperty("search");

--- a/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
+++ b/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
@@ -99,9 +99,12 @@ public class PullRequestsMergedInSprint
         while (hasMore)
         {
             queryText.variables["end_cursor"] = cursor!;
+            Console.WriteLine($"Sending query:\n{queryText}\n\n");
             var jsonData = await client.PostGraphQLRequestAsync(queryText);
 
             var searchNodes = jsonData.GetProperty("search");
+
+            Console.WriteLine($"Query response:\n{jsonData.ToString()}");
 
             foreach (var item in searchNodes.GetProperty("nodes").EnumerateArray())
                 yield return new PullRequest(item);

--- a/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
+++ b/DotNet.DocsTools/GraphQLQueries/PullRequestsMergedInSprint.cs
@@ -99,12 +99,9 @@ public class PullRequestsMergedInSprint
         while (hasMore)
         {
             queryText.variables["end_cursor"] = cursor!;
-            Console.WriteLine($"Sending query:\n{queryText.ToJsonText()}\n\n");
             var jsonData = await client.PostGraphQLRequestAsync(queryText);
 
             var searchNodes = jsonData.GetProperty("search");
-
-            Console.WriteLine($"Query response:\n{jsonData.ToString()}");
 
             foreach (var item in searchNodes.GetProperty("nodes").EnumerateArray())
                 yield return new PullRequest(item);

--- a/WhatsNew.Cli/Program.cs
+++ b/WhatsNew.Cli/Program.cs
@@ -69,6 +69,16 @@ public class Program
             Console.WriteLine($"Error message: {ex.Message}");
             return;
         }
+
+        Console.WriteLine(whatsNewConfig.LogConfigSettings());
+        if (savefile is not null)
+        {
+            Console.WriteLine($"Writing output to {savefile}");
+        } else
+        {
+            Console.WriteLine($"Writing output to {whatsNewConfig.SaveDir}");
+        }
+
         var pageGenService = new PageGenerationService(whatsNewConfig);
 
         await pageGenService.WriteMarkdownFile(savefile);

--- a/WhatsNew.Infrastructure/Models/WhatsNewConfiguration.cs
+++ b/WhatsNew.Infrastructure/Models/WhatsNewConfiguration.cs
@@ -1,6 +1,7 @@
 ﻿using DotNetDocs.Tools.GitHubCommunications;
 using DotNetDocs.Tools.Utility;
 using Microsoft.DotnetOrg.Ospo;
+using System.Text;
 
 namespace WhatsNew.Infrastructure.Models;
 
@@ -53,4 +54,17 @@ public class WhatsNewConfiguration
     /// This is the client that makes queries to the Microsoft OSPO office API.
     /// </summary>
     public OspoClient OspoClient { get; set; } = null!;
+
+    public string? LogConfigSettings()
+    {
+        StringBuilder output = new ();
+        output.AppendLine($"Repository: {Repository.Owner}/{Repository.Name}");
+        output.AppendLine($"Branch: {Repository.Branch}");
+        output.AppendLine($"DocSetProductName: {Repository.DocSetProductName}");
+        output.AppendLine($"RootDirectory: {Repository.RootDirectory}");
+        output.AppendLine($"DateRange: {DateRange.StartDate:D} - {DateRange.EndDate:D}");
+        output.AppendLine($"MarkdownFileName: {MarkdownFileName}");
+        output.AppendLine($"PathToRepoRoot: {PathToRepoRoot}");
+        return output.ToString();
+    }
 }

--- a/WhatsNew.Infrastructure/Services/PageGenerationService.cs
+++ b/WhatsNew.Infrastructure/Services/PageGenerationService.cs
@@ -40,7 +40,21 @@ public class PageGenerationService
     /// </summary>
     public async Task WriteMarkdownFile(string? existingMarkdownFile= null)
     {
-        await ProcessPullRequests();
+        var totalPRs = await ProcessPullRequests();
+
+        if (totalPRs == 0)
+        {
+            var color = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.WriteLine("No PRs found.");
+            Console.WriteLine("This is likely a problem with one of:");
+            Console.WriteLine("\t- the date range");
+            Console.WriteLine("\t- the required label");
+            Console.WriteLine("\t- GitHub permissions");
+            Console.WriteLine("Exiting.");
+            Console.ForegroundColor = color;
+            return;
+        }
 
         if (string.IsNullOrWhiteSpace(existingMarkdownFile))
         {
@@ -309,23 +323,24 @@ public class PageGenerationService
         }
     }
 
-    private async Task ProcessPullRequests()
+    private async Task<int> ProcessPullRequests()
     {
         var repo = _configuration.Repository;
         var client = _configuration.GitHubClient;
         var ospoClient = _configuration.OspoClient;
 
-        await processPRs();
+        var totalPRs = await processPRs();
 
         // If processing a private repo, fetch the PRs & community contributors from
         // the accompanying public repo. Merge private results with public results.
         if (repo.IsPrivateRepo)
         {
             repo.Name = repo.Name.Replace(PrivateRepoNameSuffix, string.Empty);
-            await processPRs();
+            totalPRs += await processPRs();
         }
+        return totalPRs;
 
-        async Task processPRs()
+        async Task<int> processPRs()
         {
             Console.ForegroundColor = ConsoleColor.DarkMagenta;
             Console.WriteLine($"== {repo.Owner}/{repo.Name} ({repo.Branch}) ==", Console.ForegroundColor);
@@ -336,8 +351,10 @@ public class PageGenerationService
                 client, repo.Owner, repo.Name, repo.Branch, repo.InclusionCriteria.Labels, _configuration.DateRange);
             var authorLoginFTECache = new Dictionary<string, bool?>();
 
+            var totalPRs = 0;
             await foreach (var item in query.PerformQuery())
             {
+                totalPRs++;
                 var prNumber = item.Number;
                 Console.WriteLine($"Processing PR {prNumber}");
 
@@ -366,6 +383,7 @@ public class PageGenerationService
                 Console.WriteLine($"{index}. {distinctExcludedContributors[index - 1]}");
             }
             Console.WriteLine();
+            return totalPRs;
         }
     }
 


### PR DESCRIPTION
Instead of sorting the configured areas in alphabetical order, use the order specified in the whatsnew.json file.

Fixes #271