### PR TITLE
Handle missing child arrays

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/QuestIssue.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssue.cs
@@ -1,9 +1,6 @@
 ﻿using DotNetDocs.Tools.GitHubCommunications;
-using DotNetDocs.Tools.GraphQLQueries;
 using Microsoft.DotnetOrg.Ospo;
-using System.Reflection.Emit;
 using System.Text.Json;
-using System.Xml.Linq;
 
 namespace DotNet.DocsTools.GitHubObjects;
 

--- a/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
+++ b/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
@@ -25,11 +25,17 @@ internal static class ResponseExtractors
         OptionalDateProperty(element, "updatedAt") ?? DateTime.Now;
 
     internal static T[] GetChildArrayElements<T>(
-        JsonElement element, 
+        JsonElement element,
         string elementName,
-        Func<JsonElement, T> selector) => 
-        (from label in element.Descendent(elementName, "nodes").EnumerateArray()
-         select selector(label)).ToArray();
+        Func<JsonElement, T> selector)
+    {
+        var array = element.Descendent(elementName, "nodes");
+        
+        return array.ValueKind == JsonValueKind.Array ? 
+            (from child in array.EnumerateArray()
+                select selector(child)).ToArray() :
+                [];
+    }
 
     private static JsonElement ChildElement(JsonElement element, string propertyName)
     {


### PR DESCRIPTION
Bad news: My last PR broke it.

Good news: Adding tests is paying off.

In all my interactive tests, the `timelineItems` node existed, even if it was empty. Oddly enough, when the SeQuester app runs, some of the issues return with that node missing. I'm still not sure why. The code adds a check that any child array exists and is an array. If not, an empty array is returned.

The added unit test verifies it.