### PR TITLE
Post install bugs

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/SequesteredIssueMutation.cs
+++ b/DotNet.DocsTools/GitHubObjects/SequesteredIssueMutation.cs
@@ -4,15 +4,6 @@ using DotNetDocs.Tools.GitHubCommunications;
 namespace DotNet.DocsTools.GitHubObjects;
 
 /// <summary>
-/// The variables for the sequester mutation.
-/// </summary>
-/// <param name="NodeID">The id of the issue to update</param>
-/// <param name="LabelIDToRemove">The ID of the label to remove</param>
-/// <param name="LabelIDToAdd">The ID of the label to add</param>
-/// <param name="BodyText">The updated body text</param>
-public readonly record struct SequesterVariables(string NodeID, string LabelIDToRemove, string LabelIDToAdd, string BodyText);
-
-/// <summary>
 /// The mutation to sequester an issue.
 /// </summary>
 /// <remarks>
@@ -20,53 +11,13 @@ public readonly record struct SequesterVariables(string NodeID, string LabelIDTo
 /// the body text is updated to add a link to the AzDo work item. Third, the "sequestered label
 /// is added.
 /// </remarks>
-public class SequesteredIssueMutation : IGitHubMutation<SequesteredIssueMutation, SequesterVariables>
+public class SequesteredIssueMutation : SequesteredIssueOrPullRequestMutation, IGitHubMutation<SequesteredIssueMutation, SequesterVariables>
 {
-    private const string sequesterPacketText = """
-      mutation SequesterIssue($nodeID: ID!, $bodyText: String!, $addLabelIDs: [ID!]!, $removeLabelIDs: [ID!]!) {
-        removeLabelsFromLabelable(input: {
-          labelableId:$nodeID
-          labelIds:$removeLabelIDs
-          clientMutationId:"dotnet-docs-tools"
-        }) {
-          labelable {
-            __typename
-          }
-          clientMutationId
-        }
-        updateIssue (
-          input: {body: $bodyText, clientMutationId:"dotnet-docs-tools", id:$nodeID }
-        ) {
-          clientMutationId
-        }
-        addLabelsToLabelable(input: {
-          labelableId:$nodeID
-          labelIds:$addLabelIDs
-          clientMutationId:"dotnet-docs-tools"
-        }) {
-          labelable {
-            __typename
-          }
-          clientMutationId
-        }
-      }
-      """;
-
     /// <summary>
     /// Construct the mutation packet
     /// </summary>
     /// <param name="variables">The set of variables to use.</param>
     /// <returns>The packet, including all variables.</returns>
-    public static GraphQLPacket GetMutationPacket(SequesterVariables variables) => 
-        new()
-        {
-            query = sequesterPacketText,
-            variables =
-            {
-                ["nodeID"] = variables.NodeID,
-                ["bodyText"] = variables.BodyText,
-                ["addLabelIDs"] = new[] { variables.LabelIDToAdd },
-                ["removeLabelIDs"] = new[] { variables.LabelIDToRemove }
-            }
-        };
+    public static GraphQLPacket GetMutationPacket(SequesterVariables variables) =>
+        GetMutationPacket(variables, true);
 }

--- a/DotNet.DocsTools/GitHubObjects/SequesteredIssueOrPullRequestMutation.cs
+++ b/DotNet.DocsTools/GitHubObjects/SequesteredIssueOrPullRequestMutation.cs
@@ -1,0 +1,96 @@
+﻿using DotNetDocs.Tools.GitHubCommunications;
+
+namespace DotNet.DocsTools.GitHubObjects;
+
+/// <summary>
+/// The variables for the sequester mutation.
+/// </summary>
+/// <param name="NodeID">The id of the issue to update</param>
+/// <param name="LabelIDToRemove">The ID of the label to remove</param>
+/// <param name="LabelIDToAdd">The ID of the label to add</param>
+/// <param name="BodyText">The updated body text</param>
+public readonly record struct SequesterVariables(string NodeID, string LabelIDToRemove, string LabelIDToAdd, string BodyText);
+
+/// <summary>
+/// The mutation to sequester an issue.
+/// </summary>
+/// <remarks>
+/// This performs three distinct actions in order. First, the "request" label is removed. Second,
+/// the body text is updated to add a link to the AzDo work item. Third, the "sequestered label
+/// is added.
+/// </remarks>
+public abstract class SequesteredIssueOrPullRequestMutation
+{
+    private const string removeLabelMutation = """
+          removeLabelsFromLabelable(input: {
+            labelableId:$nodeID
+            labelIds:$removeLabelIDs
+            clientMutationId:"dotnet-docs-tools"
+          }) {
+            labelable {
+              __typename
+            }
+            clientMutationId
+          }
+        """;
+
+    private const string addLabelMutation = """
+          addLabelsToLabelable(input: {
+            labelableId:$nodeID
+            labelIds:$addLabelIDs
+            clientMutationId:"dotnet-docs-tools"
+          }) {
+            labelable {
+              __typename
+            }
+            clientMutationId
+          }
+        """;
+
+    private const string updateIssueMutation = """
+          updateIssue (
+            input: {body: $bodyText, clientMutationId:"dotnet-docs-tools", id:$nodeID }
+          ) {
+            clientMutationId
+          }
+        """;
+    private const string updatePullRequestMutation = """
+          updatePullRequest (
+            input: {body: $bodyText, clientMutationId:"dotnet-docs-tools", id:$nodeID }
+          ) {
+            clientMutationId
+          }
+        """;
+
+    private const string sequesterPacketHeader = """
+      mutation SequesterIssue($nodeID: ID!, $bodyText: String!, $addLabelIDs: [ID!]!, $removeLabelIDs: [ID!]!) {
+      """;
+
+    private const string sequesterPacketClose = """
+      }
+      """;
+
+    /// <summary>
+    /// Construct the mutation packet
+    /// </summary>
+    /// <param name="variables">The set of variables to use.</param>
+    /// <returns>The packet, including all variables.</returns>
+    protected static GraphQLPacket GetMutationPacket(SequesterVariables variables, bool isIssue) =>
+        new()
+        {
+            query = $"""
+                {sequesterPacketHeader}
+                {removeLabelMutation}
+                {(isIssue ? updateIssueMutation : updatePullRequestMutation)}
+                {addLabelMutation}
+                {sequesterPacketClose}
+                """,
+            variables =
+            {
+                ["nodeID"] = variables.NodeID,
+                ["bodyText"] = variables.BodyText,
+                ["addLabelIDs"] = new[] { variables.LabelIDToAdd },
+                ["removeLabelIDs"] = new[] { variables.LabelIDToRemove }
+            }
+        };
+}

--- a/DotNet.DocsTools/GitHubObjects/SequesteredIssueOrPullRequestMutation.cs
+++ b/DotNet.DocsTools/GitHubObjects/SequesteredIssueOrPullRequestMutation.cs
@@ -56,7 +56,7 @@ public abstract class SequesteredIssueOrPullRequestMutation
         """;
     private const string updatePullRequestMutation = """
           updatePullRequest (
-            input: {body: $bodyText, clientMutationId:"dotnet-docs-tools", id:$nodeID }
+            input: {body: $bodyText, clientMutationId:"dotnet-docs-tools", pullRequestId:$nodeID }
           ) {
             clientMutationId
           }

--- a/DotNet.DocsTools/GitHubObjects/SequesteredPullRequestMutation.cs
+++ b/DotNet.DocsTools/GitHubObjects/SequesteredPullRequestMutation.cs
@@ -1,0 +1,14 @@
+﻿using DotNet.DocsTools.GraphQLQueries;
+using DotNetDocs.Tools.GitHubCommunications;
+
+namespace DotNet.DocsTools.GitHubObjects;
+public class SequesteredPullRequestMutation : SequesteredIssueOrPullRequestMutation, IGitHubMutation<SequesteredPullRequestMutation, SequesterVariables>
+{
+    /// <summary>
+    /// Construct the mutation packet
+    /// </summary>
+    /// <param name="variables">The set of variables to use.</param>
+    /// <returns>The packet, including all variables.</returns>
+    public static GraphQLPacket GetMutationPacket(SequesterVariables variables) =>
+        GetMutationPacket(variables, false);
+}

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
@@ -83,7 +83,7 @@ public sealed class QuestClient : IDisposable
     public async Task<JsonElement> CreateWorkItem(List<JsonPatchDocument> document)
     {
         string? json = JsonSerializer.Serialize(document, s_options);
-        Console.WriteLine($"Creating work item with:\n{json}");
+        // Console.WriteLine($"Creating work item with:\n{json}");
 
         using var request = new StringContent(json);
         request.Headers.ContentType = new MediaTypeHeaderValue("application/json-patch+json");
@@ -91,7 +91,7 @@ public sealed class QuestClient : IDisposable
 
         string createWorkItemUrl =
             $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/wit/workitems/$User%20Story?api-version=6.0&expand=Fields";
-        Console.WriteLine($"Create work item URL: \"{createWorkItemUrl}\"");
+        // Console.WriteLine($"Create work item URL: \"{createWorkItemUrl}\"");
 
         using HttpResponseMessage response = await InitiateRequestAsync(client =>
             client.PostAsync(createWorkItemUrl, request));
@@ -125,7 +125,7 @@ public sealed class QuestClient : IDisposable
     public async Task<JsonElement> PatchWorkItem(int id, List<JsonPatchDocument> document)
     {
         string? json = JsonSerializer.Serialize(document, s_options);
-        Console.WriteLine($"Patching {id} with:\n{json}");
+        // Console.WriteLine($"Patching {id} with:\n{json}");
 
         using var request = new StringContent(json);
         request.Headers.ContentType = new MediaTypeHeaderValue("application/json-patch+json");
@@ -133,7 +133,7 @@ public sealed class QuestClient : IDisposable
 
         string patchWorkItemUrl = 
             $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/wit/workitems/{id}?api-version=6.0&expand=Fields";
-        Console.WriteLine($"Patch work item URL: \"{patchWorkItemUrl}\"");
+        // Console.WriteLine($"Patch work item URL: \"{patchWorkItemUrl}\"");
 
         using HttpResponseMessage response = await InitiateRequestAsync(
             client => client.PatchAsync(patchWorkItemUrl, request));

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -246,25 +246,32 @@ public class QuestGitHubService(
     }
 
 
-    private async Task<QuestWorkItem?> LinkIssueAsync(QuestIssueOrPullRequest ghIssue, QuestIteration currentIteration, IEnumerable<QuestIteration> allIterations)
+    private async Task<QuestWorkItem?> LinkIssueAsync(QuestIssueOrPullRequest issueOrPullRequest, QuestIteration currentIteration, IEnumerable<QuestIteration> allIterations)
     {
-        int? workItem = LinkedQuestId(ghIssue);
+        int? workItem = LinkedQuestId(issueOrPullRequest);
         if (workItem is null)
         {
             // Create work item:
-            QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(ghIssue, _azdoClient, _ospoClient, areaPath, _importTriggerLabel?.Id, currentIteration, allIterations);
+            QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(issueOrPullRequest, _azdoClient, _ospoClient, areaPath, _importTriggerLabel?.Id, currentIteration, allIterations);
 
-            string linkText = $"{LinkedWorkItemComment} - {questItem.Id}]({_questLinkString}{questItem.Id})";
+            string linkText = $"[{LinkedWorkItemComment} - {questItem.Id}]({_questLinkString}{questItem.Id})";
             string updatedBody = $"""
-               {ghIssue.Body}
+               {issueOrPullRequest.Body}
 
                ---
                {linkText}
                """;
 
-            var mutation = new Mutation<SequesteredIssueMutation, SequesterVariables>(ghClient);
-
-            await mutation.PerformMutation(new SequesterVariables(ghIssue.Id, _importTriggerLabel?.Id ?? "", _importedLabel?.Id ?? "", updatedBody));
+            if (issueOrPullRequest is QuestIssue issue)
+            {
+                var issueMutation = new Mutation<SequesteredIssueMutation, SequesterVariables>(ghClient);
+                await issueMutation.PerformMutation(new SequesterVariables(issue.Id, _importTriggerLabel?.Id ?? "", _importedLabel?.Id ?? "", updatedBody));
+            }
+            else if (issueOrPullRequest is QuestPullRequest pr)
+            {
+                var prMutation = new Mutation<SequesteredPullRequestMutation, SequesterVariables>(ghClient);
+                await prMutation.PerformMutation(new SequesterVariables(pr.Id, _importTriggerLabel?.Id ?? "", _importedLabel?.Id ?? "", updatedBody));
+            }
             return questItem;
         }
         else

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -254,7 +254,7 @@ public class QuestGitHubService(
             // Create work item:
             QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(issueOrPullRequest, _azdoClient, _ospoClient, areaPath, _importTriggerLabel?.Id, currentIteration, allIterations);
 
-            string linkText = $"[{LinkedWorkItemComment} - {questItem.Id}]({_questLinkString}{questItem.Id})";
+            string linkText = $"[{LinkedWorkItemComment}{questItem.Id}]({_questLinkString}{questItem.Id})";
             string updatedBody = $"""
                {issueOrPullRequest.Body}
 


### PR DESCRIPTION
I found two bugs with the automation run overnight.

1. Typo in the link text. This made bad formats for newly sequestered issues.
2. The mutation query requires different variables and command names for issues and PRs.