### PR TITLE
Debugging sprint parsing

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -257,7 +257,7 @@ public abstract record QuestIssueOrPullRequest : Issue
 
         StoryPointSize?[] points = ResponseExtractors.GetChildArrayElements(issueNode, "projectItems", item =>
             StoryPointSize.OptionalFromJsonElement(item));
-        ProjectStoryPoints = [ ..points.ToArray()];
+        ProjectStoryPoints = [ ..points.Where(p => p is not null).ToArray()];
 
         // check state. If re-opened, don't reference the (not correct) closing PR
         ClosingPRUrl = ResponseExtractors.GetChildArrayElements(issueNode, "timelineItems", item =>

--- a/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
+++ b/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
@@ -31,7 +31,12 @@ internal static class ResponseExtractors
         Func<JsonElement, T> selector)
     {
         var array = element.Descendent(elementName, "nodes");
-        
+
+        // Debugging code:
+        if (array.ValueKind != JsonValueKind.Array)
+        {
+            Console.WriteLine($"No array of {elementName} found!");
+        }
         return array.ValueKind == JsonValueKind.Array ? 
             (from child in array.EnumerateArray()
              let childElement = selector(child)

--- a/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
+++ b/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
@@ -39,6 +39,9 @@ public record StoryPointSize
                     sz = new StoryPointSize(year, month.Substring(0, 3), size);
                 }
             }
+        } else
+        {
+            Console.WriteLine("Expect project node wasn't a JSON object");
         }
         return sz;
     }

--- a/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
+++ b/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
@@ -15,6 +15,9 @@ public record StoryPointSize
         {
             // Modify the code to store the optional month in the tuple field.
             string? projectTitle = projectItem.Descendent("project", "title").GetString();
+
+            Console.WriteLine($"Project title: {projectTitle}");
+
             // size may or may not have been set yet:
             string size = "🐂 Medium";
             string? sprintMonth = default;

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -70,7 +70,7 @@ internal class Program
             else
             {
                 await serviceWorker.ProcessIssues(
-                    org, repo, duration ?? -1, false);
+                    org, repo, duration ?? -1, true);
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Somehow, the sprint project parsing logic is failing in production.

It's passing in my unit tests, and when I run locally.

Add debugging statements to figure out why overnight.