### PR TITLE
OspoKey is the env var

### DIFF
--- a/WhatsNew.Cli/README.md
+++ b/WhatsNew.Cli/README.md
@@ -36,7 +36,7 @@ Metrics for the "what's new" pages are made available at [aka.ms/whatsnewindocs]
 
    The OSPO personal access token is required to access the OSPO API. This API determines community contributors and Microsoft employee and vendor contributors.
 1. Request a token at [Visual Studio Online](https://ossmsft.visualstudio.com/_usersSettings/tokens). You can disable all scopes *except* read:user profile.
-1. Store the token in an environment variable named "OSPO_KEY". **If you are using the GitHub Action to generate the PR automatically**, add the key as a secret in your repository:
+1. Store the token in an environment variable named "OspoKey". **If you are using the GitHub Action to generate the PR automatically**, add the key as a secret in your repository:
    - Go to **Settings** on your repo.
    - Select **Secrets**
    - Add "OSPO_KEY" as a **Repository Secret**.


### PR DESCRIPTION
If I'm not mistaken, the environment variable that the WhatsNew.Cli app is looking for is OspoKey, not OSPO_KEY. 

See https://github.com/dotnet/docs-tools/blob/b772a2b342a28276b65f15871e908732f76dac08/WhatsNew.Infrastructure/Services/ConfigurationService.cs#L28
