### PR TITLE
Clarify instructions on seQUESTer

### DIFF
--- a/actions/sequester/README.md
+++ b/actions/sequester/README.md
@@ -20,10 +20,16 @@ To install the GitHub actions:
 1. ***Add the `quest.yml` and `quest-bulk.yml` action workflow files***
    - For an example, see the [`dotnet/docs` installation](https://github.com/dotnet/docs/blob/main/.github/workflows/quest.yml). You'll likely need to change the checks on the labels.
 1. ***Add secrets for Azure Dev Ops and Microsoft Open Source Programs Office*** You'll need to add three secret tokens to access the OSPO REST APIs and Quest Azure DevOps APIs.
-   - *OSPO_KEY*: Generate a PAT [here](https://ossmsft.visualstudio.com/_usersSettings/tokens). UserProfile: Read is the only access needed.
-   - *SEQUESTER_APPID*: This is the app ID for the Sequester Action. You get this from one of the App administrators (Bill or Immo).
-   - *SEQUESTER_PRIVATEKEY*: This is the private key to authorize sequester. You get this from one of the App administrators (Bill or Immo).
-   - *QUEST_KEY*: Generate a PAT [here](https://dev.azure.com/msft-skilling/_usersSettings/tokens). *WorkItems*: Read/Write, *Project & Team*: Read/Write, and *Identity*: Read access are needed.
+
+   - **SEQUESTER_APPID**: This is the app ID for the Sequester Action. Get this from one of the App admins (Bill or Immo).
+   - **SEQUESTER_PRIVATEKEY**: This is the private key to authorize sequester. Get this from one of the App admins (Bill or Immo).
+   - **OSPO_KEY**: Generate a PAT at [OSSMSFT](https://ossmsft.visualstudio.com/_usersSettings/tokens) with the following permissions:
+     - *UserProfile*: Read
+   - **QUEST_KEY**: Generate a PAT at [MSFT-SKILLING](https://dev.azure.com/msft-skilling/_usersSettings/tokens) with the following permissions:
+     - *Identity*: Read
+     - *Project & Team*: Read/Write
+     - *WorkItems*: Read/Write
+
 1. ***Start applying labels***
    - Add the trigger label to any issue, and it will be imported into Quest.
 


### PR DESCRIPTION
Because I sort of skimmed and made assumptions about the links, I missed a key point, that the keys go in different devops. I made some improvements to help myself (and anyone else) in the future.

- Reordered the keys themselves to have the two you create together.
- Made it explicit that there are different locations where the keys are created.
- Ordered the permissions for the QUEST_KEY according to where they land in the actual UI (alphabetical)
- Made permissions bullets so they're easier to pick out.

**Before**
![image](https://github.com/dotnet/docs-tools/assets/67293991/82c8ee25-2369-428c-8d86-8fadb051d71e)

**After**
![image](https://github.com/dotnet/docs-tools/assets/67293991/c6e6c5f0-d400-4a96-bde0-3e53c68ea2b9)
