### PR TITLE
Fix story point calculation

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -30,20 +30,30 @@ public static class IssueExtensions
         return sizes.FirstOrDefault();
     }
 
-    public static int? QuestStoryPoint(this StoryPointSize storyPointSize) => 
-        storyPointSize.Size.Length switch
+    public static int? QuestStoryPoint(this StoryPointSize storyPointSize)
+    {
+        if (storyPointSize.Size.Contains("Tiny"))
         {
-            < 6 => null,
-            _ => storyPointSize.Size[..6] switch
-            {
-                "🦔 Tiny" => 1,
-                "🐇 Smal" => 3,
-                "🐂 Medi" => 5,
-                "🦑 Larg" => 8,
-                "🐋 X-La" => 13,
-                _ => null,
-            }
-        };
+            return 1;
+        }
+        else if (storyPointSize.Size.Contains("Small"))
+        {
+            return 3;
+        }
+        else if (storyPointSize.Size.Contains("Medium"))
+        {
+            return 5;
+        }
+        else if (storyPointSize.Size.Contains("Large"))
+        {
+            return 8;
+        }
+        else if (storyPointSize.Size.Contains("X-Large"))
+        {
+            return 13;
+        }
+        return null;
+    }
 
     public static QuestIteration? ProjectIteration(this StoryPointSize storyPoints, IEnumerable<QuestIteration> iterations)
     {

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -152,29 +152,18 @@ public class QuestWorkItem
             Console.WriteLine("No GitHub sprint project found - using current iteration");
         }
         QuestIteration? iteration = iterationSize?.ProjectIteration(allIterations);
-        if (iteration is not null)
+        patchDocument.Add(new JsonPatchDocument
         {
-            patchDocument.Add(new JsonPatchDocument
-            {
-                Operation = Op.Add,
-                Path = "/fields/System.IterationPath",
-                Value = iteration.Path,
-            });
-        }
-        else
-        { // default to the current iteration:
-            patchDocument.Add(new JsonPatchDocument
-            {
-                Operation = Op.Add,
-                Path = "/fields/System.IterationPath",
-                Value = currentIteration.Path,
-            });
-        }
+            Operation = Op.Add,
+            Path = "/fields/System.IterationPath",
+            Value = iteration?.Path ?? currentIteration.Path,
+        });
         if (iterationSize?.QuestStoryPoint() is not null)
         {
             patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
+                From = default,
                 Path = "/fields/Microsoft.VSTS.Scheduling.StoryPoints",
                 Value = iterationSize.QuestStoryPoint(),
             });

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -362,6 +362,7 @@ public class QuestGitHubService(
             patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
+                From = default,
                 Path = "/fields/Microsoft.VSTS.Scheduling.StoryPoints",
                 Value = iterationSize.QuestStoryPoint(),
             });


### PR DESCRIPTION
The pattern matching for the story point size wasn't working because the first character was multi-character emoji.

So, use the old style string.Contains method rather than pattern matching.

Second, add the `From` key for consistency.