### PR TITLE
Enable seQuester to add a parent node to a work item imported from GitHub

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -24,7 +24,6 @@ internal class Program
         string? questConfigPath = null,
         string? branch = null)
     {
-        Console.WriteLine(duration);
         try
         {
             if (repo.Contains('/'))

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -99,6 +99,8 @@ internal class Program
                 options.AzureDevOps.AreaPath,
                 options.ImportTriggerLabel,
                 options.ImportedLabel,
+                options.DefaultParentNode,
+                options.ParentNodes,
                 bulkImport);
     }
 }

--- a/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
@@ -1,4 +1,4 @@
-namespace Quest2GitHub.Tests;
+﻿namespace Quest2GitHub.Tests;
 
 public class ImportOptionsTests
 {
@@ -16,6 +16,8 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal(":world_map: reQUEST", actual.ImportTriggerLabel);
         Assert.Equal(":pushpin: seQUESTered", actual.ImportedLabel);
+        Assert.Equal(0, actual.DefaultParentNode);
+        Assert.Empty(actual.ParentNodes);
 
         // API keys object
         Assert.Null(actual.ApiKeys);
@@ -69,6 +71,9 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal("trigger-import", actual.ImportTriggerLabel);
         Assert.Equal("imported", actual.ImportedLabel);
+        Assert.Equal(228485, actual.DefaultParentNode);
+        Assert.Equal(199082, actual.ParentNodes.Single(p => p.Label == "okr-health").ParentNodeId);
+        Assert.Equal(227484, actual.ParentNodes.Single(p => p.Label == "dotnet-csharp/svc").ParentNodeId);
 
         // Azure DevOps nested options
         Assert.Equal("org", actual.AzureDevOps.Org);
@@ -164,6 +169,8 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal("trigger-label", actual.ImportTriggerLabel);
         Assert.Equal("imported-label", actual.ImportedLabel);
+        Assert.Equal(0, actual.DefaultParentNode);
+        Assert.Empty(actual.ParentNodes);
 
         // Azure DevOps nested options
         Assert.Equal("fake-ado-org", actual.AzureDevOps.Org);

--- a/actions/sequester/Quest2GitHub.Tests/quest-import.json
+++ b/actions/sequester/Quest2GitHub.Tests/quest-import.json
@@ -1,18 +1,29 @@
 {
-  "ImportOptions": {
-    "GitHubOrg": "org",
-    "GitHubRepo": "repo",
-    "AzureDevOps": {
-      "Org": "org",
-      "Project": "proj",
-      "AreaPath": "path"
-    },
-    "ApiKeys": {
-      "GitHubToken": "ght",
-      "OSPOKey": "okey",
-      "QuestKey":  "qkey"
-    },
-    "ImportTriggerLabel": "trigger-import",
-    "ImportedLabel": "imported"
-  }
+    "ImportOptions": {
+        "GitHubOrg": "org",
+        "GitHubRepo": "repo",
+        "AzureDevOps": {
+            "Org": "org",
+            "Project": "proj",
+            "AreaPath": "path"
+        },
+        "ApiKeys": {
+            "GitHubToken": "ght",
+            "OSPOKey": "okey",
+            "QuestKey": "qkey"
+        },
+        "ImportTriggerLabel": "trigger-import",
+        "ImportedLabel": "imported",
+        "ParentNodes": [
+            {
+                "Label": "okr-health",
+                "ParentNodeId": 199082
+            },
+            {
+                "Label": "dotnet-csharp/svc",
+                "ParentNodeId": 227484
+            }
+        ],
+        "DefaultParentNode": 228485
+    }
 }

--- a/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
+++ b/actions/sequester/Quest2GitHub/AzDoClientServices/QuestClient.cs
@@ -25,9 +25,9 @@ public sealed class QuestClient : IDisposable
     };
 
     private readonly HttpClient _client;
-    private readonly string _questOrg;
     private readonly AsyncRetryPolicy _retryPolicy;
 
+    public string QuestOrg { get; }
     public string QuestProject { get; }
 
     /// <summary>
@@ -38,7 +38,7 @@ public sealed class QuestClient : IDisposable
     /// <param name="project">The Azure DevOps project</param>
     public QuestClient(string token, string org, string project)
     {
-        _questOrg = org;
+        QuestOrg = org;
         QuestProject = project;
         _client = new HttpClient();
         _client.DefaultRequestHeaders.Accept.Add(
@@ -65,7 +65,7 @@ public sealed class QuestClient : IDisposable
     public async Task<JsonElement> RetrieveAllIterations()
     {
         string getIterationsUrl =
-            $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/work/teamsettings/iterations?api-version=7.1-preview.1";
+            $"https://dev.azure.com/{QuestOrg}/{QuestProject}/_apis/work/teamsettings/iterations?api-version=7.1-preview.1";
 
         using HttpResponseMessage response = await InitiateRequestAsync(
             client => client.GetAsync(getIterationsUrl));
@@ -90,7 +90,7 @@ public sealed class QuestClient : IDisposable
         request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
 
         string createWorkItemUrl =
-            $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/wit/workitems/$User%20Story?api-version=6.0&expand=Fields";
+            $"https://dev.azure.com/{QuestOrg}/{QuestProject}/_apis/wit/workitems/$User%20Story?api-version=7.1&$expand=relations";
         // Console.WriteLine($"Create work item URL: \"{createWorkItemUrl}\"");
 
         using HttpResponseMessage response = await InitiateRequestAsync(client =>
@@ -107,7 +107,7 @@ public sealed class QuestClient : IDisposable
     public async Task<JsonElement> GetWorkItem(int id)
     {
         string getWorkItemUrl = 
-            $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/wit/workitems/{id}?api-version=6.0&expand=Fields";
+            $"https://dev.azure.com/{QuestOrg}/{QuestProject}/_apis/wit/workitems/{id}?$expand=relations";
         Console.WriteLine($"Get work item URL: \"{getWorkItemUrl}\"");
 
         using HttpResponseMessage response = await InitiateRequestAsync(
@@ -132,7 +132,7 @@ public sealed class QuestClient : IDisposable
         request.Headers.Add("Accepts", MediaTypeNames.Application.Json);
 
         string patchWorkItemUrl = 
-            $"https://dev.azure.com/{_questOrg}/{QuestProject}/_apis/wit/workitems/{id}?api-version=6.0&expand=Fields";
+            $"https://dev.azure.com/{QuestOrg}/{QuestProject}/_apis/wit/workitems/{id}?api-version=7.1&$expand=relations";
         // Console.WriteLine($"Patch work item URL: \"{patchWorkItemUrl}\"");
 
         using HttpResponseMessage response = await InitiateRequestAsync(
@@ -169,7 +169,7 @@ public sealed class QuestClient : IDisposable
 
     public async Task<AzDoIdentity?> GetIDFromEmail(string emailAddress)
     {
-        string url = $"https://vssps.dev.azure.com/{_questOrg}/_apis/identities?searchFilter=General&filterValue={emailAddress}&queryMembership=None&api-version=7.1-preview.1";
+        string url = $"https://vssps.dev.azure.com/{QuestOrg}/_apis/identities?searchFilter=General&filterValue={emailAddress}&queryMembership=None&api-version=7.1-preview.1";
         using HttpResponseMessage response = await InitiateRequestAsync(
             client => client.GetAsync(url));
 

--- a/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
@@ -101,6 +101,12 @@ public static class ImportOptionsExtensions
         Console.WriteLine($"  options.AzureDevOps.Org = \"{options?.AzureDevOps?.Org}\"");
         Console.WriteLine($"  options.AzureDevOps.Project = \"{options?.AzureDevOps?.Project}\"");
         Console.WriteLine($"  options.AzureDevOps.AreaPath = \"{options?.AzureDevOps?.AreaPath}\"");
+        Console.WriteLine($"  options.DefaultParentNode = \"{options?.DefaultParentNode}\"");
+        Console.WriteLine($"  options.ParentNodes:");
+        foreach (var node in options?.ParentNodes ?? Enumerable.Empty<ParentForLabel>())
+        {
+            Console.WriteLine($"    {node.Label, -20}  ==> {node.ParentNodeId}");
+        }
     }
 
     static ImportOptions EnsureApiKeys(ImportOptions options)

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -338,13 +338,13 @@ public class QuestWorkItem
     {
         int id = root.GetProperty("id").GetInt32();
         JsonElement fields = root.GetProperty("fields");
-        int? parentID = fields.TryGetProperty("System.Parent", out var parentNode) ?
+        int? parentID = fields.TryGetProperty("System.Parent", out JsonElement parentNode) ?
             parentNode.GetInt32() : null;
         int? parentRelationIndex = null;
         if (parentID is not null)
         {
-            var relType = "System.LinkTypes.Hierarchy-Reverse";
-            var parentRelation = root.GetProperty("relations")
+            string relType = "System.LinkTypes.Hierarchy-Reverse";
+            (JsonElement r, int Index) parentRelation = root.GetProperty("relations")
                 .EnumerateArray().Select((r,Index) => (r,Index))
                 .FirstOrDefault(t => t.r.GetProperty("rel").GetString() == relType);
             parentRelationIndex = parentRelation.Index;

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -141,12 +141,22 @@ public class QuestWorkItem
         ];
         if (parentId is not null)
         {
+            var parentRelation = new Relation
+            {
+                RelationName = "System.LinkTypes.Hierarchy-Reverse",
+                Url = $"https://dev.azure.com/{questClient.QuestOrg}/{questClient.QuestProject}/_apis/wit/workItems/{parentId}",
+                Attributes =
+                {
+                    ["name"] = "Parent",
+                    ["isLocked"] = false
+                }
+            };
             patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
-                Path = "/fields/System.Parent",
+                Path = "/relations/-",
                 From = default,
-                Value = parentId
+                Value = parentRelation
             });
         }
 

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -348,7 +348,6 @@ public class QuestWorkItem
                 .EnumerateArray().Select((r,Index) => (r,Index))
                 .FirstOrDefault(t => t.r.GetProperty("rel").GetString() == relType);
             parentRelationIndex = parentRelation.Index;
-
         }
 
         string title = fields.GetProperty("System.Title").GetString()!;

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -1,5 +1,7 @@
 ﻿namespace Quest2GitHub.Options;
 
+public record struct ParentForLabel(string Label, int ParentNodeId);
+
 public sealed record class ImportOptions
 {
     /// <summary>
@@ -42,4 +44,24 @@ public sealed record class ImportOptions
     /// <a href="https://github.com/ikatyang/emoji-cheat-sheet"></a>
     /// </remarks>
     public required string ImportedLabel { get; init; } = ":pushpin: seQUESTered";
+
+    /// <summary>
+    /// The set of labels where specific parent nodes should be used.
+    /// </summary>
+    /// <remarks>
+    /// When a work item gets created, or updated, it should have
+    /// the correct parent. Some labels in a repo will use specific parents.
+    /// This is a list of pairs rather than a dictionary because we want them
+    /// ordered. The first label found on an issue will be used for the parent.
+    /// </remarks>
+    public required List<ParentForLabel> ParentNodes { get; init; } = [];
+
+    /// <summary>
+    /// The default parent node for any quest item.
+    /// </summary>
+    /// <remarks>
+    /// If an issue doesn't match any of the configured labels
+    /// the default parent node is set for the work item.
+    /// </remarks>
+    public required int DefaultParentNode { get; init; }
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -309,6 +309,15 @@ public class QuestGitHubService(
         List<JsonPatchDocument> patchDocument = [];
         if ((parentId != 0) && (parentId != questItem.ParentWorkItemId))
         {
+            if (questItem.ParentWorkItemId != 0)
+            {
+                // Remove the existing parent relation.
+                patchDocument.Add(new JsonPatchDocument
+                {
+                    Operation = Op.Remove,
+                    Path = "/relations/" + questItem.ParentRelationIndex,
+                });
+            };
             var parentRelation = new Relation
             {
                 RelationName = "System.LinkTypes.Hierarchy-Reverse",

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -1,5 +1,6 @@
 ﻿using DotNet.DocsTools.GitHubObjects;
 using DotNet.DocsTools.GraphQLQueries;
+using Quest2GitHub.AzureDevOpsCommunications;
 
 namespace Quest2GitHub;
 
@@ -308,13 +309,24 @@ public class QuestGitHubService(
         List<JsonPatchDocument> patchDocument = [];
         if ((parentId != 0) && (parentId != questItem.ParentWorkItemId))
         {
-            JsonPatchDocument parentPatch = new()
+            var parentRelation = new Relation
+            {
+                RelationName = "System.LinkTypes.Hierarchy-Reverse",
+                Url = $"https://dev.azure.com/{_azdoClient.QuestOrg}/{_azdoClient.QuestProject}/_apis/wit/workItems/{parentId}",
+                Attributes =
+                {
+                    ["name"] = "Parent",
+                    ["isLocked"] = false
+                }
+            };
+
+            patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
-                Path = "/fields/System.Parent",
-                Value = parentId
-            };
-            patchDocument.Add(parentPatch);
+                Path = "/relations/-",
+                From = default,
+                Value = parentRelation
+            });
         }
         if ((questAssigneeID is not null) && (questAssigneeID?.Id != questItem.AssignedToId))
         {

--- a/actions/sequester/README.md
+++ b/actions/sequester/README.md
@@ -38,7 +38,7 @@ To install the GitHub actions:
 ## Suggestions for future releases
 
 - [ ] Populate the "GitHub Repo" field in Azure DevOps to make reporting by repository easier.
-- [ ] Add Epics (configurable) as a parent of user stories on import.
+- [X] Add Epics (configurable) as a parent of user stories on import.
 - [X] Update the label block in Quest when an issue is closed. That way, any "OKR" labels get added when the work item is completed. This would be a simplified version of updating all labels when labels are added or removed.
 - [ ] Integrate with Repoman. That tool already performs a number of actions on different events in the repo. The code underlying these events could be ported there.
 - [ ] Encapsulate services into their own projects/packages, and share them as needed.
@@ -63,6 +63,17 @@ The consuming repository would ideally define the config file. As an example, it
   },
   "ImportTriggerLabel": ":world_map: reQUEST",
   "ImportedLabel": ":pushpin: seQUESTered"
+  "ParentNodes": [
+  {
+    "Label": "okr-health",
+    "ParentNodeId": 199082
+  },
+  {
+    "Label": "dotnet-csharp/svc",
+    "ParentNodeId": 227484
+  }
+  ],
+  "DefaultParentNode": 228485
 }
 ```
 


### PR DESCRIPTION
Fixes #313 

Enhance the quest.config to define a default parent work item, and a set of label / parent work item pairs. 

When an item is created, put it under the proper parent. When updating work items, if the appropriate parent has changed, update the parent.
