### PR TITLE
Make app resilient when OSPO API is off

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -223,7 +223,9 @@ public class QuestWorkItem
     {
         var body = new StringBuilder($"<p>Imported from: {issue.LinkText}</p>");
         body.AppendLine($"<p>Author: {issue.FormattedAuthorLoginName}</p>");
-        body.AppendLine(issue.BodyHtml.ScrubContent());
+        var assigneeStrings = issue.Assignees.Select(a => $"{a.Login}-({a.Name})").ToArray();
+        body.AppendLine($"<p>Assignees: {string.Join(", ", assigneeStrings)}</p>");  
+        body.AppendLine(issue.BodyHtml?.ScrubContent());
         if (issue.Labels.Length != 0)
         {
             body.AppendLine($"<p><b>Labels:</b></p>");

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -300,21 +300,15 @@ public class QuestGitHubService(
             questAssigneeID = await _azdoClient.GetIDFromEmail(ghAssigneeEmailAddress);
         }
         List<JsonPatchDocument> patchDocument = [];
-        if (questAssigneeID?.Id != questItem.AssignedToId)
+        if ((questAssigneeID is not null) && (questAssigneeID?.Id != questItem.AssignedToId))
         {
             // build patch document for assignment.
-            JsonPatchDocument? assignPatch = (questAssigneeID is null) ?
-                new JsonPatchDocument
-                {
-                    Operation = Op.Remove,
-                    Path = "/fields/System.AssignedTo",
-                } :
-                new JsonPatchDocument
-                {
-                    Operation = Op.Add,
-                    Path = "/fields/System.AssignedTo",
-                    Value = questAssigneeID,
-                };
+            JsonPatchDocument assignPatch = new ()
+            {
+                Operation = Op.Add,
+                Path = "/fields/System.AssignedTo",
+                Value = questAssigneeID,
+            };
             patchDocument.Add(assignPatch);
         }
         bool questItemOpen = questItem.State is not "Closed";


### PR DESCRIPTION
The OSPO REST API has been turned off. In the interim, run our apps in a degraded mode.

As a result, if the GH issue assignee is null, don't remove an existing AzDo assignee.