### PR TITLE
Fix two production bugs

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -74,9 +74,9 @@ public class QuestWorkItem
     /// Starting with the next semester, our work items
     /// must have a parent Epic or Feature.
     /// Note that existing work items may not have
-    /// a current parent, which would make a null parent ID.
+    /// a current parent, which would make a 0 parent ID.
     /// </remarks>
-    public required int? ParentWorkItemId { get; init; }
+    public required int ParentWorkItemId { get; init; }
 
     /// <summary>
     /// The index of the parent relation in the relations array.
@@ -118,7 +118,7 @@ public class QuestWorkItem
     /// Json element.
     /// </remarks>
     public static async Task<QuestWorkItem> CreateWorkItemAsync(QuestIssueOrPullRequest issue,
-        int? parentId,
+        int parentId,
         QuestClient questClient,
         OspoClient ospoClient,
         string path,
@@ -149,7 +149,7 @@ public class QuestWorkItem
                 Value = areaPath,
             }
         ];
-        if (parentId is not null)
+        if (parentId != 0)
         {
             var parentRelation = new Relation
             {
@@ -338,10 +338,10 @@ public class QuestWorkItem
     {
         int id = root.GetProperty("id").GetInt32();
         JsonElement fields = root.GetProperty("fields");
-        int? parentID = fields.TryGetProperty("System.Parent", out JsonElement parentNode) ?
-            parentNode.GetInt32() : null;
+        int parentID = fields.TryGetProperty("System.Parent", out JsonElement parentNode) ?
+            parentNode.GetInt32() : 0;
         int? parentRelationIndex = null;
-        if (parentID is not null)
+        if (parentID != 0)
         {
             string relType = "System.LinkTypes.Hierarchy-Reverse";
             (JsonElement r, int Index) parentRelation = root.GetProperty("relations")

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -54,7 +54,7 @@ public sealed record class ImportOptions
     /// This is a list of pairs rather than a dictionary because we want them
     /// ordered. The first label found on an issue will be used for the parent.
     /// </remarks>
-    public required List<ParentForLabel> ParentNodes { get; init; } = [];
+    public List<ParentForLabel> ParentNodes { get; init; } = [];
 
     /// <summary>
     /// The default parent node for any quest item.
@@ -63,5 +63,5 @@ public sealed record class ImportOptions
     /// If an issue doesn't match any of the configured labels
     /// the default parent node is set for the work item.
     /// </remarks>
-    public required int DefaultParentNode { get; init; }
+    public int DefaultParentNode { get; init; }
 }


### PR DESCRIPTION
First problem: If the config file was missing any info, the whole operation failed. These should have been resilient and used the defaults, but no.

Second problem: If a work item didn't have a parent, the existing relation didn't exist, and the "remove relation" patch failed.

Remove the `required` modifier on the optional properties. That fixed the first issue.

For the second issue, use `0` as an invalid parent ID, instead of `null`. Fix the import logic to match.

Now, for both the current parent and the updated parent, `0` is invalid. Any other value is expected to be a valid work item.