### PR TITLE
Heisenbug take 2

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -72,6 +72,12 @@ internal class Program
                     org, repo, duration ?? -1, false);
             }
         }
+        catch (InvalidOperationException e) when (e.Message.StartsWith("HTTP error:"))
+        {
+            Console.Error.WriteLine($"!!!ERROR!!! Could not communicate with Quest Azure DevOps server. Did your PAT expire?");
+            Console.Error.WriteLine($"::  -- {e.Message} -- ");
+            Console.Error.WriteLine(e.ToString());
+        }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"::  -- {ex.Message} -- ");

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -76,10 +76,18 @@ public class QuestGitHubService(
         DateTime historyThreshold = (duration == -1) ? DateTime.MinValue : DateTime.Now.AddDays(-duration);
         int totalImport = 0;
         int totalSkipped = 0;
+        Console.WriteLine("-----   Starting processing issues.          --------");
         var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
         await ProcessItems(issueQueryEnumerable);
+        Console.WriteLine("-----   Finished processing issues.          --------");
+        // UGH: If this immediately starts the next query, the query
+        // often fails. Let those GitHub servers rest a bit.
+        await Task.Delay(1000);
+
+        Console.WriteLine("-----   Starting processing pull requests.   --------");
         var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
         await ProcessItems(prQueryEnumerable);
+        Console.WriteLine("-----   Finished processing pull requests.   --------");
 
         async Task ProcessItems(IAsyncEnumerable<QuestIssueOrPullRequest> items)
         {

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -76,18 +76,15 @@ public class QuestGitHubService(
         DateTime historyThreshold = (duration == -1) ? DateTime.MinValue : DateTime.Now.AddDays(-duration);
         int totalImport = 0;
         int totalSkipped = 0;
-        Console.WriteLine("-----   Starting processing issues.          --------");
-        var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
-        await ProcessItems(issueQueryEnumerable);
-        Console.WriteLine("-----   Finished processing issues.          --------");
-        // UGH: If this immediately starts the next query, the query
-        // often fails. Let those GitHub servers rest a bit.
-        await Task.Delay(1000);
 
         Console.WriteLine("-----   Starting processing pull requests.   --------");
         var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
         await ProcessItems(prQueryEnumerable);
         Console.WriteLine("-----   Finished processing pull requests.   --------");
+        Console.WriteLine("-----   Starting processing issues.          --------");
+        var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
+        await ProcessItems(issueQueryEnumerable);
+        Console.WriteLine("-----   Finished processing issues.          --------");
 
         async Task ProcessItems(IAsyncEnumerable<QuestIssueOrPullRequest> items)
         {


### PR DESCRIPTION
There are two changes here.

First, add a diagnostic on failure that a likely cause is the expiration of a PAT.

Second, try querying PRs before issues. My working theory is that PRs don't span multiple pages and update the cursor. 
