### PR TITLE
Minor clean up and switch to Bearer token header

### DIFF
--- a/DotNet.DocsTools/DotNet.DocsTools.csproj
+++ b/DotNet.DocsTools/DotNet.DocsTools.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CliWrap" Version="3.6.6" />
 		<PackageReference Include="GitHubJwt" Version="0.0.6" />
 		<PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
 		<PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />

--- a/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
@@ -1,0 +1,64 @@
+﻿using CliWrap;
+using CliWrap.Buffered;
+using DotNetDocs.Tools.Utility;
+using Microsoft.DotnetOrg.Ospo;
+
+namespace DotNet.DocsTools.OspoClientServices;
+
+public static class OspoClientFactory
+{
+    public static async Task<OspoClient> CreateAsync()
+    {
+        await LoginAsync();
+
+        var token = await GetTokenAsync();
+
+        return new OspoClient(token, true);
+    }
+
+    private static async ValueTask LoginAsync()
+    {
+        // az login
+        var result = await Cli.Wrap("az")
+            .WithArguments("login")
+            .WithValidation(CommandResultValidation.None)
+            .ExecuteAsync();
+
+        if (result.IsSuccess == false)
+        {
+            Console.WriteLine($"The 'az login' command supposedly failed with {result.ExitCode} after {result.RunTime}.");
+        }
+    }
+
+    private static async ValueTask<string> GetTokenAsync()
+    {
+        var resource = CommandLineUtility.GetEnvVariable(
+            "OSMP_API_AUDIENCE", "Unable to get the scoped/resource.", null);
+
+        // az account get-access-token
+        //   --query 'accessToken'
+        //   -o tsv
+        //   --scope "links"
+        //   --resource "Some test audience"
+        var tokenResult = await Cli.Wrap("az")
+            .WithArguments(
+            [
+                "account",
+                "get-access-token",
+                "--query", "accessToken",
+                "-o", "tsv",
+                "--scope", "links",
+                "--resource", resource
+            ])
+            .ExecuteBufferedAsync();
+
+        var token = tokenResult.StandardOutput.Trim();
+
+        if (string.IsNullOrEmpty(token))
+        {
+            Console.WriteLine($"az account get-access-token failed");
+        }
+
+        return token;
+    }
+}

--- a/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
@@ -20,7 +20,12 @@ public static class OspoClientFactory
     {
         // az login
         var result = await Cli.Wrap("az")
-            .WithArguments("login")
+            .WithArguments(
+            [
+                "login",
+                "--scope",
+                "links"
+            ])
             .WithValidation(CommandResultValidation.None)
             .ExecuteAsync();
 
@@ -32,8 +37,8 @@ public static class OspoClientFactory
 
     private static async ValueTask<string> GetTokenAsync()
     {
-        var resource = CommandLineUtility.GetEnvVariable(
-            "OSMP_API_AUDIENCE", "Unable to get the scoped/resource.", null);
+        //var resource = CommandLineUtility.GetEnvVariable(
+        //    "OSMP_API_AUDIENCE", "Unable to get the scoped/resource.", null);
 
         // az account get-access-token
         //   --query 'accessToken'
@@ -48,7 +53,7 @@ public static class OspoClientFactory
                 "--query", "accessToken",
                 "-o", "tsv",
                 "--scope", "links",
-                "--resource", resource
+                //"--resource", resource
             ])
             .ExecuteBufferedAsync();
 

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -1,0 +1,10 @@
+﻿using DotNet.DocsTools.OspoClientServices;
+
+var client = await OspoClientFactory.CreateAsync();
+
+var link = await client.GetAsync("IEvangelist");
+
+if (link is not null)
+{
+    _ = link;
+}

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotNet.DocsTools\DotNet.DocsTools.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs-tools.sln
+++ b/docs-tools.sln
@@ -1,4 +1,3 @@
-﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33205.214
@@ -78,6 +77,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XmlDocConflictResolver", "X
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RepoManCheckerCLI", "RepoManChecker\RepoManCheckerCLI.csproj", "{1C59182B-9266-43FB-8398-86AE0F5012D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox", "Sandbox\Sandbox.csproj", "{C93AB0B6-1B1A-4172-909B-81249CDAFC6D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -116,6 +117,10 @@ Global
 		{BCDD57DA-6C08-49CA-8F03-D4FC4FF2ABCC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCDD57DA-6C08-49CA-8F03-D4FC4FF2ABCC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCDD57DA-6C08-49CA-8F03-D4FC4FF2ABCC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C93AB0B6-1B1A-4172-909B-81249CDAFC6D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C93AB0B6-1B1A-4172-909B-81249CDAFC6D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C93AB0B6-1B1A-4172-909B-81249CDAFC6D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C93AB0B6-1B1A-4172-909B-81249CDAFC6D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D9BB2E16-F28E-4BA7-98F9-4303891C3C34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D9BB2E16-F28E-4BA7-98F9-4303891C3C34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9BB2E16-F28E-4BA7-98F9-4303891C3C34}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
In this PR:

- Minor clean-up for readability, and pattern matching.
- Convert the Authorization HTTP Header to Bearer w/o encoding.

Since the `token` parameter in the .ctor is assigned from the `OspoKey` environment variable value, we'd need to ensure that consuming GitHub Action workflows are updated to get a request token, similar to the following flow:

```yml
name: POC API 🐿️
 
on:
  push:
    branches: [main]
 
permissions:
  id-token: write
  contents: read
 
jobs:
  build:
    name: 'POC 🚛'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - name: Azure OpenID Connect ✨
        uses: azure/login@v1
        with:
          client-id: ${{ secrets.CLIENT_ID }}
          tenant-id: ${{ secrets.TENANT_ID }}
          allow-no-subscriptions: true
 
      - name: OSMP API access
        run: |
          TOKEN=$(az account get-access-token --query 'accessToken' -o tsv --resource ${{ secrets.OSMP_API_AUDIENCE }})
          echo "OspoKey=$TOKEN" >> $GITHUB_ENV
```

This would need to happen before calling into quest, so that the `OspoKey` is assigned from the returned `TOKEN`. The main question we'd need answered is, where do we get these values, I'm assuming Jeff Wilcox would know:

- `secrets.CLIENT_ID`
- `secrets.TENANT_ID`
- `secrets.OSMP_API_AUDIENCE`