### PR TITLE
The heisenbug appears again

### DIFF
--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -77,14 +77,16 @@ public class QuestGitHubService(
         int totalImport = 0;
         int totalSkipped = 0;
 
-        Console.WriteLine("-----   Starting processing pull requests.   --------");
-        var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
-        await ProcessItems(prQueryEnumerable);
-        Console.WriteLine("-----   Finished processing pull requests.   --------");
         Console.WriteLine("-----   Starting processing issues.          --------");
         var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
         await ProcessItems(issueQueryEnumerable);
         Console.WriteLine("-----   Finished processing issues.          --------");
+        // UGH: The GH servers need a break after processing the issues.
+        await Task.Delay(2500);
+        Console.WriteLine("-----   Starting processing pull requests.   --------");
+        var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
+        await ProcessItems(prQueryEnumerable);
+        Console.WriteLine("-----   Finished processing pull requests.   --------");
 
         async Task ProcessItems(IAsyncEnumerable<QuestIssueOrPullRequest> items)
         {


### PR DESCRIPTION
Almost all the work items are for issues, not PR review. So, go back to processing issues first.

Second, add a delay before processing PRs. That seems to minimize the occurrence of the failures.