### PR TITLE
use OIDC in the code for what's new

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -331,9 +331,9 @@ public abstract record QuestIssueOrPullRequest : Issue
     /// <param name="ospoClient">The Open Source program office client service.</param>
     /// <returns>The email address of the assignee. Null if unassigned, or the assignee is not a 
     /// Microsoft FTE.</returns>
-    public async Task<string?> QueryAssignedMicrosoftEmailAddressAsync(OspoClient ospoClient)
+    public async Task<string?> QueryAssignedMicrosoftEmailAddressAsync(OspoClient? ospoClient)
     {
-        if (Assignees.Length != 0)
+        if ((Assignees.Length != 0) && (ospoClient is not null))
         {
             OspoLink? identity = await ospoClient.GetAsync(Assignees.First().Login);
             // This feels like a hack, but it is necessary.

--- a/DotNet.DocsTools/OspoClientServices/OspoClient.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClient.cs
@@ -75,7 +75,7 @@ public sealed class OspoClient : IDisposable
 
         if (result is { Outcome: OutcomeType.Failure })
         {
-            Console.WriteLine("WARNING: OSPO REST API failure. Check access token rights");
+            Console.WriteLine("WARNING: OSPO REST API failure. Check authorization.");
             Console.WriteLine("WARNING: App running in degraded mode.");
             return default;
         }
@@ -106,7 +106,7 @@ public sealed class OspoClient : IDisposable
 
         if (result is { Outcome: OutcomeType.Failure })
         {
-            Console.WriteLine("WARNING: OSPO REST API failure. Check access token rights");
+            Console.WriteLine("WARNING: OSPO REST API failure. Check authorization.");
             Console.WriteLine("WARNING: App running in degraded mode.");
             _allLinks = new();
         }

--- a/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
@@ -1,19 +1,18 @@
 ﻿using CliWrap;
 using CliWrap.Buffered;
-using DotNetDocs.Tools.Utility;
 using Microsoft.DotnetOrg.Ospo;
 
 namespace DotNet.DocsTools.OspoClientServices;
 
 public static class OspoClientFactory
 {
-    public static async Task<OspoClient> CreateAsync()
+    public static async Task<OspoClient> CreateAsync(bool useCache)
     {
         await LoginAsync();
 
         var token = await GetTokenAsync();
 
-        return new OspoClient(token, true);
+        return new OspoClient(token, useCache);
     }
 
     private static async ValueTask LoginAsync()
@@ -53,7 +52,7 @@ public static class OspoClientFactory
                 "--query", "accessToken",
                 "-o", "tsv",
                 "--scope", "links",
-                //"--resource", resource
+                //"--resource", "resource"
             ])
             .ExecuteBufferedAsync();
 

--- a/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
+++ b/DotNet.DocsTools/OspoClientServices/OspoClientFactory.cs
@@ -6,24 +6,31 @@ namespace DotNet.DocsTools.OspoClientServices;
 
 public static class OspoClientFactory
 {
-    public static async Task<OspoClient> CreateAsync(bool useCache)
+    public static async Task<OspoClient?> CreateAsync(string? clientID, string? tenantID, string? resourceAudience, bool useCache)
     {
-        await LoginAsync();
+        if (string.IsNullOrEmpty(clientID) ||
+            string.IsNullOrEmpty(tenantID) ||
+            string.IsNullOrEmpty(resourceAudience))
+        {
+            return null;
+        }
+        await LoginAsync(clientID, tenantID);
 
-        var token = await GetTokenAsync();
+        var token = await GetTokenAsync(resourceAudience);
 
         return new OspoClient(token, useCache);
     }
 
-    private static async ValueTask LoginAsync()
+    private static async ValueTask LoginAsync(string clientID, string tenantID)
     {
         // az login
         var result = await Cli.Wrap("az")
             .WithArguments(
             [
                 "login",
-                "--scope",
-                "links"
+                "--clientID", clientID,
+                "--tenantID", tenantID,
+                "--scope", "links"
             ])
             .WithValidation(CommandResultValidation.None)
             .ExecuteAsync();
@@ -34,10 +41,8 @@ public static class OspoClientFactory
         }
     }
 
-    private static async ValueTask<string> GetTokenAsync()
+    private static async ValueTask<string> GetTokenAsync(string resourceAudience)
     {
-        //var resource = CommandLineUtility.GetEnvVariable(
-        //    "OSMP_API_AUDIENCE", "Unable to get the scoped/resource.", null);
 
         // az account get-access-token
         //   --query 'accessToken'
@@ -52,7 +57,7 @@ public static class OspoClientFactory
                 "--query", "accessToken",
                 "-o", "tsv",
                 "--scope", "links",
-                //"--resource", "resource"
+                "--resource", resourceAudience
             ])
             .ExecuteBufferedAsync();
 

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -1,8 +1,13 @@
 ﻿using DotNet.DocsTools.OspoClientServices;
 
-var client = await OspoClientFactory.CreateAsync(true);
+// The actual values should be secrets. DO NOT CHECK THEM IN!!!!
+var clientID = args.Length == 3 ? args[0] : null;
+var tenantID = args.Length == 3 ? args[1] : null;
+var resourceAudience = args.Length == 3 ? args[2] : null;
 
-var link = await client.GetAsync("IEvangelist");
+var client = await OspoClientFactory.CreateAsync(clientID!, tenantID!, resourceAudience!, true);
+
+var link = client != null ? await client.GetAsync("IEvangelist") : null;
 
 if (link is not null)
 {

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -1,6 +1,6 @@
 ﻿using DotNet.DocsTools.OspoClientServices;
 
-var client = await OspoClientFactory.CreateAsync();
+var client = await OspoClientFactory.CreateAsync(true);
 
 var link = await client.GetAsync("IEvangelist");
 

--- a/WhatsNew.Cli/Program.cs
+++ b/WhatsNew.Cli/Program.cs
@@ -51,7 +51,7 @@ public class Program
         // The GH API returns JSON on auth failures, so those queries fail
         // with very cryptic error messages. This try/catch block catches
         // those errors and provides a more helpful message.
-        WhatsNewConfiguration? whatsNewConfig = default;
+        WhatsNewConfiguration? whatsNewConfig;
         try
         {
             var configService = new ConfigurationService();

--- a/WhatsNew.Infrastructure/Models/WhatsNewConfiguration.cs
+++ b/WhatsNew.Infrastructure/Models/WhatsNewConfiguration.cs
@@ -53,7 +53,7 @@ public class WhatsNewConfiguration
     /// <summary>
     /// This is the client that makes queries to the Microsoft OSPO office API.
     /// </summary>
-    public OspoClient OspoClient { get; set; } = null!;
+    public OspoClient? OspoClient { get; set; }
 
     public string? LogConfigSettings()
     {

--- a/WhatsNew.Infrastructure/Services/ConfigurationService.cs
+++ b/WhatsNew.Infrastructure/Services/ConfigurationService.cs
@@ -1,12 +1,12 @@
 ﻿using DotNetDocs.Tools.GitHubCommunications;
 using DotNetDocs.Tools.Utility;
-using Microsoft.DotnetOrg.Ospo;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WhatsNew.Infrastructure.Models;
 using DotNetDocs.Tools.GraphQLQueries;
 using DotNet.DocsTools.GitHubObjects;
+using DotNet.DocsTools.OspoClientServices;
 
 namespace WhatsNew.Infrastructure.Services;
 
@@ -25,9 +25,6 @@ public class ConfigurationService
         var key = config["GitHubKey"];
         if (string.IsNullOrWhiteSpace(key))
             throw new InvalidOperationException("Store your GitHub personal access token in the 'GitHubKey' environment variable.");
-        var ospoKey = config["OspoKey"];
-        if (string.IsNullOrWhiteSpace(ospoKey))
-            throw new InvalidOperationException("Store your 1ES personal access token in the 'OspoKey' environment variable.");
 
         var dateRange = new DateRange(input.DateStart, input.DateEnd);
         string configFileName, configFileContents, markdownFileName;
@@ -43,7 +40,7 @@ public class ConfigurationService
 
         var client = IGitHubClient.CreateGitHubClient(key);
 
-        var ospoClient = new OspoClient(ospoKey, true);
+        var ospoClient = await OspoClientFactory.CreateAsync(true);
 
         if (string.IsNullOrWhiteSpace(input.Branch))
         {

--- a/WhatsNew.Infrastructure/Services/ConfigurationService.cs
+++ b/WhatsNew.Infrastructure/Services/ConfigurationService.cs
@@ -7,6 +7,7 @@ using WhatsNew.Infrastructure.Models;
 using DotNetDocs.Tools.GraphQLQueries;
 using DotNet.DocsTools.GitHubObjects;
 using DotNet.DocsTools.OspoClientServices;
+using Microsoft.DotnetOrg.Ospo;
 
 namespace WhatsNew.Infrastructure.Services;
 
@@ -40,7 +41,27 @@ public class ConfigurationService
 
         var client = IGitHubClient.CreateGitHubClient(key);
 
-        var ospoClient = await OspoClientFactory.CreateAsync(true);
+        var clientId = config["CLIENT_ID"];
+        var tenentId = config["TENANT_ID"];
+        var resourceAudience = config["OSMP_API_AUDIENCE"];
+        var deprecatedOspoKey = config["OSPOKey"];
+        OspoClient? ospoClient = (clientId, tenentId, resourceAudience) switch
+        {
+            (null, _, _) => null,
+            (_, null, _) => null,
+            (_, _, null) => null,
+            (_, _, _) => await OspoClientFactory.CreateAsync(clientId, tenentId, resourceAudience, true),
+        };
+
+        if (deprecatedOspoKey is not null)
+        {
+            Console.WriteLine("Warning: PAT based authorization is deprecated. Please use OIDC authorization.");
+            Console.WriteLine("Contact tool owners to get OIDC setup.");
+        }
+        if (ospoClient is null)
+        {
+            Console.WriteLine("Warning: Microsoft FTEs won't be filtered from the contributor list.");
+        }
 
         if (string.IsNullOrWhiteSpace(input.Branch))
         {

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -97,7 +97,6 @@ internal class Program
 
         return new QuestGitHubService(
                 gitHubClient,
-                options.ApiKeys.OSPOKey,
                 options.ApiKeys.QuestKey,
                 options.AzureDevOps.Org,
                 options.AzureDevOps.Project,

--- a/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
@@ -82,7 +82,6 @@ public class ImportOptionsTests
 
         // API keys object
         Assert.Equal("ght", actual.ApiKeys?.GitHubToken);
-        Assert.Equal("okey", actual.ApiKeys?.OSPOKey);
         Assert.Equal("qkey", actual.ApiKeys?.QuestKey);
     }
 
@@ -112,7 +111,7 @@ public class ImportOptionsTests
         {
             ApiKeys = new()
             {
-                GitHubToken = "", OSPOKey = " ", QuestKey = " ", SequesterPrivateKey = " ", SequesterAppID = 0
+                GitHubToken = "", QuestKey = " ", SequesterPrivateKey = " ", SequesterAppID = 0
             }
         };
 
@@ -138,7 +137,6 @@ public class ImportOptionsTests
             .ValidateOptions();
 
         Assert.Equal("fake-ght", actual.ApiKeys!.GitHubToken);
-        Assert.Equal("fake-ospo-key", actual.ApiKeys.OSPOKey);
         Assert.Equal("fake-quest-key", actual.ApiKeys.QuestKey);
     }
 
@@ -179,7 +177,6 @@ public class ImportOptionsTests
 
         // API keys object
         Assert.Equal("fake-ght", actual.ApiKeys?.GitHubToken);
-        Assert.Equal("fake-ospo-key", actual.ApiKeys?.OSPOKey);
         Assert.Equal("fake-quest-key", actual.ApiKeys?.QuestKey);
     }
 }

--- a/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
@@ -44,26 +44,6 @@ public static class ImportOptionsExtensions
             """);
 
         AttemptFallbackOrThrowIfNullOrWhiteSpace(
-            options.ApiKeys?.OSPOKey,
-            "OSPOKey",
-            fallbackValue =>
-            {
-                options = EnsureApiKeys(options);
-                options = options with
-                {
-                    ApiKeys = options.ApiKeys! with
-                    {
-                        OSPOKey = fallbackValue
-                    }
-                };
-            },
-            nameof(options.ApiKeys.OSPOKey),
-            """
-            An OSPO API key is required. In a consuming GitHub Action workflow assign it as follows:
-              ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_API_KEY }}
-            """);
-
-        AttemptFallbackOrThrowIfNullOrWhiteSpace(
             options.ApiKeys?.QuestKey,
             "QuestKey",
             fallbackValue =>
@@ -119,7 +99,6 @@ public static class ImportOptionsExtensions
                 {
                     SequesterPrivateKey = "",
                     GitHubToken = "",
-                    OSPOKey = "",
                     QuestKey = "",
                     SequesterAppID = 0
                 }

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -120,7 +120,7 @@ public class QuestWorkItem
     public static async Task<QuestWorkItem> CreateWorkItemAsync(QuestIssueOrPullRequest issue,
         int parentId,
         QuestClient questClient,
-        OspoClient ospoClient,
+        OspoClient? ospoClient,
         string path,
         string? requestLabelNodeId,
         QuestIteration currentIteration,

--- a/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
+++ b/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
@@ -25,6 +25,51 @@ public sealed record class ApiKeys
     public required string GitHubToken { get; init; }
 
     /// <summary>
+    /// The Microsoft Open Source Programs Office API key.
+    /// </summary>
+    /// <remarks>
+    /// This key is deprecated. The PAT based authentication has been removed. Read it from
+    /// the config to write a warning message to update to OIDC based authentication.
+    /// </remarks>
+    public string? OSPOKey { get; init; }
+
+    /// <summary>
+    /// The client ID for identifying this app with OSPO.
+    /// </summary>
+    /// <remarks>
+    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__ClientId</c>:
+    /// <code>
+    /// env:
+    ///   ImportOptions__ApiKeys__OSPOClientID: ${{ secrets.CLIENT_ID }}
+    /// </code>
+    /// </remarks>
+    public string? OSPOClientID { get; init; }
+
+    /// <summary>
+    /// The Tenant ID for identifying this app with OSPO.
+    /// </summary>
+    /// <remarks>
+    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__TenantId</c>:
+    /// <code>
+    /// env:
+    ///   ImportOptions__ApiKeys__OSPOTenantID: ${{ secrets.TENANT_ID }}
+    /// </code>
+    /// </remarks>
+    public string? OSPOTenantID{ get; init; }
+
+    /// <summary>
+    /// The resource for this app with OSPO.
+    /// </summary>
+    /// <remarks>
+    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__ResourceAudience</c>:
+    /// <code>
+    /// env:
+    ///   ImportOptions__ApiKeys__OSPOResourceAudience: ${{ secrets.OSMP_API_AUDIENCE }}
+    /// </code>
+    /// </remarks>
+    public string? OSPOResourceAudience { get; init; }
+
+    /// <summary>
     /// The Azure DevOps API key.
     /// </summary>
     /// <remarks>

--- a/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
+++ b/actions/sequester/Quest2GitHub/Options/ApiKeys.cs
@@ -25,18 +25,6 @@ public sealed record class ApiKeys
     public required string GitHubToken { get; init; }
 
     /// <summary>
-    /// The Microsoft Open Source Programs Office API key.
-    /// </summary>
-    /// <remarks>
-    /// Assign this from an environment variable with the following key, <c>ImportOptions__ApiKeys__OSPOKey</c>:
-    /// <code>
-    /// env:
-    ///   ImportOptions__ApiKeys__OSPOKey: ${{ secrets.OSPO_API_KEY }}
-    /// </code>
-    /// </remarks>
-    public required string OSPOKey { get; init; }
-
-    /// <summary>
     /// The Azure DevOps API key.
     /// </summary>
     /// <remarks>

--- a/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
+++ b/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
@@ -10,11 +10,22 @@ internal sealed class EnvironmentVariableReader
         // If missing, the action runs using repo-only rights.
         var oauthPrivateKey = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterPrivateKey", "SequesterPrivateKey"), false);
         var appIDString = CoalesceEnvVar(("ImportOptions__ApiKeys__SequesterAppID", "SequesterAppID"), false);
+
+        var clientId = CoalesceEnvVar(("ImportOptions__ApiKeys__CLIENT_ID", "CLIENT_ID"), false);
+        var tenentId = CoalesceEnvVar(("ImportOptions__ApiKeys__TENANT_ID", "TENANT_ID"), false);
+        var resourceAudience = CoalesceEnvVar(("ImportOptions__ApiKeys__OSMP_API_AUDIENCE", "OSMP_API_AUDIENCE"), false);
+        var deprecatedOspoKey = CoalesceEnvVar(("ImportOptions__ApiKeys__OSPOKey", "OSPOKey"), false);
+
+
         if (!int.TryParse(appIDString, out int appID)) appID = 0;
 
         return new ApiKeys()
         {
             GitHubToken = githubToken,
+            OSPOClientID = clientId,
+            OSPOTenantID = tenentId,
+            OSPOResourceAudience = resourceAudience,
+            OSPOKey = deprecatedOspoKey,
             QuestKey = questKey,
             SequesterPrivateKey = oauthPrivateKey,
             SequesterAppID = appID

--- a/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
+++ b/actions/sequester/Quest2GitHub/Options/EnvironmentVariableReader.cs
@@ -5,7 +5,6 @@ internal sealed class EnvironmentVariableReader
     internal static ApiKeys GetApiKeys()
     {
         var githubToken = CoalesceEnvVar(("ImportOptions__ApiKeys__GitHubToken", "GitHubKey"));
-        var ospoKey = CoalesceEnvVar(("ImportOptions__ApiKeys__OSPOKey", "OSPOKey"));
         var questKey = CoalesceEnvVar(("ImportOptions__ApiKeys__QuestKey", "QuestKey"));
         // These keys are used when the app is run as an org enabled action. They are optional. 
         // If missing, the action runs using repo-only rights.
@@ -16,7 +15,6 @@ internal sealed class EnvironmentVariableReader
         return new ApiKeys()
         {
             GitHubToken = githubToken,
-            OSPOKey = ospoKey,
             QuestKey = questKey,
             SequesterPrivateKey = oauthPrivateKey,
             SequesterAppID = appID

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -1,7 +1,6 @@
 ﻿using DotNet.DocsTools.GitHubObjects;
 using DotNet.DocsTools.GraphQLQueries;
 using DotNet.DocsTools.OspoClientServices;
-using Quest2GitHub.AzureDevOpsCommunications;
 
 namespace Quest2GitHub;
 
@@ -16,7 +15,7 @@ namespace Quest2GitHub;
 /// Initialize the service.
 /// </remarks>
 /// <param name="ghClient">GitHub client</param>
-/// <param name="ospoKey">MS Open Source Programs Office personal access token</param>
+/// <param name="ospoClient">MS Open Source Programs Office client</param>
 /// <param name="azdoKey">Azure Dev Ops personal access token</param>
 /// <param name="questOrg">The Azure Dev ops organization</param>
 /// <param name="questProject">The Azure Dev ops project</param>
@@ -25,13 +24,13 @@ namespace Quest2GitHub;
 /// <param name="importedLabelText">The text of the label that indicates an issue has been imported</param>
 /// <param name="defaultParentNode">The ID of the default parent work item ID.</param>
 /// <param name="parentNodes">A dictionary of label / parent ID pairs.</param>
-/// <param name="bulkImport">True if this run is doing a bulk import.</param>
 /// <remarks>
 /// The OAuth token takes precedence over the GitHub token, if both are 
 /// present.
 /// </remarks>
 public class QuestGitHubService(
     IGitHubClient ghClient,
+    OspoClient? ospoClient,
     string azdoKey,
     string questOrg,
     string questProject,
@@ -39,12 +38,11 @@ public class QuestGitHubService(
     string importTriggerLabelText,
     string importedLabelText,
     int defaultParentNode,
-    List<ParentForLabel> parentNodes,
-    bool bulkImport) : IDisposable
+    List<ParentForLabel> parentNodes) : IDisposable
 {
     private const string LinkedWorkItemComment = "Associated WorkItem - ";
     private readonly QuestClient _azdoClient = new(azdoKey, questOrg, questProject);
-    private OspoClient? _ospoClient;
+    private readonly OspoClient? _ospoClient = ospoClient;
     private readonly string _questLinkString = $"https://dev.azure.com/{questOrg}/{questProject}/_workitems/edit/";
 
     private GitHubLabel? _importTriggerLabel;
@@ -61,10 +59,6 @@ public class QuestGitHubService(
     /// <returns></returns>
     public async Task ProcessIssues(string organization, string repository, int duration, bool dryRun)
     {
-        _ospoClient = await OspoClientFactory.CreateAsync(true);
-        // Trigger the OSPO bulk import before making any edits to any issue:
-        await _ospoClient.GetAllAsync();
-
         if (_importTriggerLabel is null || _importedLabel is null)
         {
             await RetrieveLabelIdsAsync(organization, repository);
@@ -143,9 +137,6 @@ public class QuestGitHubService(
     /// <returns>A task representing the current operation</returns>
     public async Task ProcessIssue(string gitHubOrganization, string gitHubRepository, int issueNumber)
     {
-        // Trigger the OSPO bulk import before making any edits to any issue:
-        await _ospoClient.GetAllAsync();
-
         if (_importTriggerLabel is null || _importedLabel is null)
         {
             await RetrieveLabelIdsAsync(gitHubOrganization, gitHubRepository);

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -1,5 +1,6 @@
 ﻿using DotNet.DocsTools.GitHubObjects;
 using DotNet.DocsTools.GraphQLQueries;
+using DotNet.DocsTools.OspoClientServices;
 using Quest2GitHub.AzureDevOpsCommunications;
 
 namespace Quest2GitHub;
@@ -31,7 +32,6 @@ namespace Quest2GitHub;
 /// </remarks>
 public class QuestGitHubService(
     IGitHubClient ghClient,
-    string ospoKey,
     string azdoKey,
     string questOrg,
     string questProject,
@@ -44,7 +44,7 @@ public class QuestGitHubService(
 {
     private const string LinkedWorkItemComment = "Associated WorkItem - ";
     private readonly QuestClient _azdoClient = new(azdoKey, questOrg, questProject);
-    private readonly OspoClient _ospoClient = new(ospoKey, bulkImport);
+    private OspoClient? _ospoClient;
     private readonly string _questLinkString = $"https://dev.azure.com/{questOrg}/{questProject}/_workitems/edit/";
 
     private GitHubLabel? _importTriggerLabel;
@@ -61,6 +61,7 @@ public class QuestGitHubService(
     /// <returns></returns>
     public async Task ProcessIssues(string organization, string repository, int duration, bool dryRun)
     {
+        _ospoClient = await OspoClientFactory.CreateAsync(true);
         // Trigger the OSPO bulk import before making any edits to any issue:
         await _ospoClient.GetAllAsync();
 


### PR DESCRIPTION
Update both SeQuester and WhatsNewCLI to use the new OIDC authorization for connecting to the OSPO client.

- Check for the old (deprecated) PAT token configuration. Issue a warning to upgrade and how the apps will work in a degraded mode.
- Configure and use the new keys to authorize access using the new tokens and protocol. If that fails because the keys are null, issue a warning. (In other failures, it will throw an exception).

If the client object is null, run the apps in a degraded mode.


