### PR TITLE
Force token regeneration

### DIFF
--- a/DotNet.DocsTools/GitHubClientServices/IGitHubClient.cs
+++ b/DotNet.DocsTools/GitHubClientServices/IGitHubClient.cs
@@ -33,9 +33,19 @@ public interface IGitHubClient : IDisposable
     /// <remarks>
     /// Send the GET request to the API endpoint, then
     /// process the response for a success code and return the parsed
-    /// JSONdocument.
+    /// JSON document.
     /// </remarks>
     Task<JsonDocument> GetReposRESTRequestAsync(params string[] restPath);
+
+    /// <summary>
+    /// When the implementation uses a bearer token, regenerate it.
+    /// </summary>
+    /// <remarks>
+    /// When a process runs for a long enough time, the bearer token will
+    /// expire.
+    /// </remarks>
+    /// <returns>The task running that will regenerate the token.</returns>
+    Task RegenerateBearerToken() => Task.CompletedTask;
 
     /// <summary>
     /// Create a default GitHub client.

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -81,8 +81,8 @@ public class QuestGitHubService(
         var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
         await ProcessItems(issueQueryEnumerable);
         Console.WriteLine("-----   Finished processing issues.          --------");
-        // UGH: The GH servers need a break after processing the issues.
-        await Task.Delay(2500);
+        Console.WriteLine("     ----- Regenerating bearer token   ------");
+        await ghClient.RegenerateBearerToken();
         Console.WriteLine("-----   Starting processing pull requests.   --------");
         var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
         await ProcessItems(prQueryEnumerable);


### PR DESCRIPTION
The timing bug has reappeared for pull requests. Looking at all the timestamps, it's my current theory that the bearer token expires while working on the pull requests.

So, this change forces the process to generate a new bearer token between processing issues and processing pull requests.
