### PR TITLE
[snippets] Add special exit for sln deleted

### DIFF
--- a/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
+++ b/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/snippets5000/PullRequestSimulations/data.json
+++ b/snippets5000/PullRequestSimulations/data.json
@@ -216,6 +216,17 @@
       }
     ]
   },
+    {
+        "Name": "Delete - SLN - Projects remain",
+        "CountOfEmptyResults": 1,
+        "ExpectedResults": null,
+        "Items": [
+            {
+                "ItemType": "Delete",
+                "Path": "snippets/good/normal/somefile.sln"
+            }
+        ]
+    },
   {
     "Name": "Create - New project, is in old solution",
     "ExpectedResults": [

--- a/snippets5000/Snippets5000/PullRequestProcessor.cs
+++ b/snippets5000/Snippets5000/PullRequestProcessor.cs
@@ -87,7 +87,7 @@ internal class PullRequestProcessor
         List<string> projectsFound = new List<string>();
 
         // Special exit for solution deleted. Any artifacts left over should be caught by the other checks
-        if (Path.GetExtension(itemFileName).Equals(".sln", StringComparison.OrdinalIgnoreCase) && itemWasDeleted)
+        if (itemWasDeleted && Path.GetExtension(itemFileName).Equals(".sln", StringComparison.OrdinalIgnoreCase))
             return null;
 
         // Check for the project/solution to test with was found

--- a/snippets5000/Snippets5000/PullRequestProcessor.cs
+++ b/snippets5000/Snippets5000/PullRequestProcessor.cs
@@ -86,6 +86,10 @@ internal class PullRequestProcessor
         bool allProjectsFoundInSln = false;
         List<string> projectsFound = new List<string>();
 
+        // Special exit for solution deleted. Any artifacts left over should be caught by the other checks
+        if (Path.GetExtension(itemFileName).Equals(".sln", StringComparison.OrdinalIgnoreCase) && itemWasDeleted)
+            return null;
+
         // Check for the project/solution to test with was found
         FindProjectOrSolution(rootDir, itemPath, out string? project, out int countOfSln, out int countOfProjs, out int countOfCode, out int countOfSpecial, ref projectsFound);
 


### PR DESCRIPTION
- Updated test project to .NET 8.
- Added test case for "SLN deleted files remain"
- Logic to exit if SLN file is deleted. Other normal tests will catch any invalid files left over.