### PR TITLE
Remove named tuples where not needed

### DIFF
--- a/PackageIndexer/DotnetPackageIndex.cs
+++ b/PackageIndexer/DotnetPackageIndex.cs
@@ -70,7 +70,7 @@ public static class DotnetPackageIndex
             throw new ApplicationException("NuGetOrg should be the only feed.");
     }
 
-    private static async Task<IReadOnlyList<(PackageIdentity version, bool isDeprecated)>> GetPackagesFromNuGetOrgAsync(NuGetFeed feed)
+    private static async Task<IReadOnlyList<(PackageIdentity packageId, bool isDeprecated)>> GetPackagesFromNuGetOrgAsync(NuGetFeed feed)
     {
         Console.WriteLine("Fetching owner information...");
         Dictionary<string, string[]> ownerInformation = await feed.GetOwnerMappingAsync();

--- a/PackageIndexer/NuGet/NuGetFeed.cs
+++ b/PackageIndexer/NuGet/NuGetFeed.cs
@@ -153,7 +153,7 @@ public sealed class NuGetFeed(string feedUrl)
             logger,
             cancellationToken);
 
-        List<(NuGetVersion, bool)> versions = new();
+        List<(NuGetVersion, bool)> versions = [];
 
         foreach (IPackageSearchMetadata package in packages)
         {


### PR DESCRIPTION
It looks less cluttered to remove the names where they're not needed for clarity. But I left the names where they do add clarity.