### PR TITLE
Add tags in Azure DevOps based on GitHub issue labels

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -115,6 +115,7 @@ internal class Program
                 options.ImportTriggerLabel,
                 options.ImportedLabel,
                 options.DefaultParentNode,
-                options.ParentNodes);
+                options.ParentNodes,
+                options.WorkItemTags);
     }
 }

--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -91,4 +91,22 @@ public static class IssueExtensions
         }
         return default;
     }
+
+    /// <summary>
+    /// Return tags for a given issue
+    /// </summary>
+    /// <param name="issue">The GitHub issue or pull request</param>
+    /// <param name="tags">The mapping from issue to tag</param>
+    /// <returns>An enumerable of tags</returns>
+    public static IEnumerable<string> WorkItemTagsForIssue(this QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags)
+    {
+        foreach (var label in issue.Labels)
+        {
+            var tag = tags.FirstOrDefault(t => t.Label == label.Name);
+            if (tag.Tag is not null)
+            {
+                yield return tag.Tag;
+            }
+        }
+    }
 }

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -2,6 +2,8 @@
 
 public record struct ParentForLabel(string Label, int ParentNodeId);
 
+public record struct LabelToTagMap(string Label, string Tag);
+
 public sealed record class ImportOptions
 {
     /// <summary>
@@ -64,4 +66,13 @@ public sealed record class ImportOptions
     /// the default parent node is set for the work item.
     /// </remarks>
     public int DefaultParentNode { get; init; }
+
+    /// <summary>
+    /// A map of GitHub labels to Azure DevOps tags.
+    /// </summary>
+    /// <remarks>
+    /// If an issue has the matching label, add the corresponding tag to
+    /// the mapped AzureDevOps item.
+    /// </remarks>
+    public List<LabelToTagMap> WorkItemTags { get; init; } = [];
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -37,7 +37,8 @@ public class QuestGitHubService(
     string importTriggerLabelText,
     string importedLabelText,
     int defaultParentNode,
-    List<ParentForLabel> parentNodes) : IDisposable
+    List<ParentForLabel> parentNodes,
+    IEnumerable<LabelToTagMap> tagMap) : IDisposable
 {
     private const string LinkedWorkItemComment = "Associated WorkItem - ";
     private readonly QuestClient _azdoClient = new(azdoKey, questOrg, questProject);
@@ -95,7 +96,7 @@ public class QuestGitHubService(
                     {
                         if (questItem != null)
                         {
-                            await UpdateWorkItemAsync(questItem, item, _allIterations);
+                            await UpdateWorkItemAsync(questItem, item, _allIterations, tagMap);
                         }
                         else
                         {
@@ -183,7 +184,7 @@ public class QuestGitHubService(
             {
                 // This allows a human to force a manual update: just add the trigger label.
                 // Note that it updates even if the item is closed.
-                await UpdateWorkItemAsync(questItem, ghIssue, _allIterations);
+                await UpdateWorkItemAsync(questItem, ghIssue, _allIterations, tagMap);
 
             }
             // Next, if the item is already linked, consider any updates.
@@ -194,7 +195,7 @@ public class QuestGitHubService(
         }
         else if (sequestered && questItem is not null)
         {
-            await UpdateWorkItemAsync(questItem, ghIssue, _allIterations);
+            await UpdateWorkItemAsync(questItem, ghIssue, _allIterations, tagMap);
         }
     }
 
@@ -252,7 +253,8 @@ public class QuestGitHubService(
         if (workItem is null)
         {
             // Create work item:
-            QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(issueOrPullRequest, parentId, _azdoClient, _ospoClient, areaPath, _importTriggerLabel?.Id, currentIteration, allIterations);
+            QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(issueOrPullRequest, parentId, _azdoClient, _ospoClient, areaPath,
+                _importTriggerLabel?.Id, currentIteration, allIterations, tagMap);
 
             string linkText = $"[{LinkedWorkItemComment}{questItem.Id}]({_questLinkString}{questItem.Id})";
             string updatedBody = $"""
@@ -291,7 +293,10 @@ public class QuestGitHubService(
         }
     }
 
-    private async Task<QuestWorkItem?> UpdateWorkItemAsync(QuestWorkItem questItem, QuestIssueOrPullRequest ghIssue, IEnumerable<QuestIteration> allIterations)
+    private async Task<QuestWorkItem?> UpdateWorkItemAsync(QuestWorkItem questItem,
+        QuestIssueOrPullRequest ghIssue,
+        IEnumerable<QuestIteration> allIterations,
+        IEnumerable<LabelToTagMap> tagMap)
     {
         int parentId = parentIdFromIssue(ghIssue);
         string? ghAssigneeEmailAddress = await ghIssue.QueryAssignedMicrosoftEmailAddressAsync(_ospoClient);
@@ -392,6 +397,20 @@ public class QuestGitHubService(
                 Value = iterationSize.QuestStoryPoint(),
             });
         }
+        var tags = from t in ghIssue.WorkItemTagsForIssue(tagMap)
+                   where !questItem.Tags.Contains(t)
+                   select t;
+        if (tags.Any())
+        {
+            string azDoTags = string.Join(";", tags);
+            patchDocument.Add(new JsonPatchDocument
+            {
+                Operation = Op.Add,
+                Path = "/fields/System.Tags",
+                Value = azDoTags
+            });
+        }
+
         QuestWorkItem? newItem = default;
         if (patchDocument.Count != 0)
         {

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -245,7 +245,6 @@ public class QuestGitHubService(
         return [.. iterations];
     }
 
-
     private async Task<QuestWorkItem?> LinkIssueAsync(QuestIssueOrPullRequest issueOrPullRequest, QuestIteration currentIteration, IEnumerable<QuestIteration> allIterations)
     {
         int? workItem = LinkedQuestId(issueOrPullRequest);


### PR DESCRIPTION
Fixes dotnet/docs-tools#314

Add tags in an Azure Work Item based on configured GitHub issue labels.

This facilitates reporting for those that use AzureDevOps to reporting.