### PR TITLE
A couple small workarounds

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -8,7 +8,10 @@ public class QuestWorkItem
     // Keep track of failures to update the closing PR.
     // For any given run, if the REST call to add a closing PR
     // fails, stop sending invalid requests.
-    private static bool? s_linkedGitHubRepo;
+    // 7/9/2024: Set this to false. GitHub integration links
+    // are currently disabled. Linking to the closing PR always fails.
+    // So, don't try for now.
+    private static bool? s_linkedGitHubRepo = false;
 
     private string _title = "";
 

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -76,12 +76,12 @@ public class QuestGitHubService(
         var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
         await ProcessItems(issueQueryEnumerable);
         Console.WriteLine("-----   Finished processing issues.          --------");
-        Console.WriteLine("     ----- Regenerating bearer token   ------");
+        //Console.WriteLine("     ----- Regenerating bearer token   ------");
         await ghClient.RegenerateBearerToken();
-        Console.WriteLine("-----   Starting processing pull requests.   --------");
-        var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
-        await ProcessItems(prQueryEnumerable);
-        Console.WriteLine("-----   Finished processing pull requests.   --------");
+        //Console.WriteLine("-----   Starting processing pull requests.   --------");
+        //var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
+        //await ProcessItems(prQueryEnumerable);
+        //Console.WriteLine("-----   Finished processing pull requests.   --------");
 
         async Task ProcessItems(IAsyncEnumerable<QuestIssueOrPullRequest> items)
         {


### PR DESCRIPTION
First, comment out the portion that SeQuester's PRs. The GitHub query is failing, and the error message indicates a GitHub problem.

Second, disable the code that adds the linked closing PR. GitHub integration is disabled in our AzDo repo, so it will always fail.