### PR TITLE
Re-enable seQuestering PRs

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -163,17 +163,6 @@ public abstract record QuestIssueOrPullRequest : Issue
                     name
                   }
                 }
-                timelineItems(last: 5) {
-                  nodes {
-                    ... on ClosedEvent {
-                      closer {
-                        ... on PullRequest {
-                          url
-                        }
-                      }
-                    }
-                  }
-                }
                 projectItems(first: 25) {
                   ... on ProjectV2ItemConnection {
                     nodes {

--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -130,13 +130,36 @@ public abstract record QuestIssueOrPullRequest : Issue
         query FindUpdatedIssues($organization: String!, $repository: String!, $questlabels: [String!], $cursor: String) {
           repository(owner: $organization, name: $repository) {
             issues(
-    """ + EnumerationQueryBody;
+    """ + EnumerationQueryBody +
+    """
+            timelineItems(last: 5) {
+                nodes {
+                ... on ClosedEvent {
+                    closer {
+                    ... on PullRequest {
+                        url
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    }
+    """;
 
     protected const string EnumerateQuestPullRequestQueryText = """
         query FindUpdatedPullRequests($organization: String!, $repository: String!, $questlabels: [String!], $cursor: String) {
           repository(owner: $organization, name: $repository) {
             pullRequests(
-    """ + EnumerationQueryBody;
+    """ + EnumerationQueryBody +
+    """
+            }
+          }
+        }
+    }
+    """;
 
     private const string EnumerationQueryBody = """
               first: 25
@@ -215,13 +238,9 @@ public abstract record QuestIssueOrPullRequest : Issue
                     bodyHTML
                   }
                 }
-              }
-            }
-          }
-        }
         """;
 
-    private protected QuestIssueOrPullRequest(JsonElement issueNode, string organization, string repository) : base(issueNode)
+    private protected QuestIssueOrPullRequest(JsonElement issueNode, string organization, string repository, bool includeTimeLine=true) : base(issueNode)
     {
         var author = Actor.FromJsonElement(ResponseExtractors.GetAuthorChildElement(issueNode));
         FormattedAuthorLoginName = (author is not null) ?
@@ -249,10 +268,13 @@ public abstract record QuestIssueOrPullRequest : Issue
         ProjectStoryPoints = [ ..points.Where(p => p is not null).ToArray()];
 
         // check state. If re-opened, don't reference the (not correct) closing PR
-        ClosingPRUrl = ResponseExtractors.GetChildArrayElements(issueNode, "timelineItems", item =>
-            (item.TryGetProperty("closer", out JsonElement closer) && closer.ValueKind == JsonValueKind.Object) ?
-            ResponseExtractors.OptionalStringProperty(closer, "url")
-            : default).LastOrDefault(url => url is not null);
+        if (includeTimeLine)
+        {
+            ClosingPRUrl = ResponseExtractors.GetChildArrayElements(issueNode, "timelineItems", item =>
+                (item.TryGetProperty("closer", out JsonElement closer) && closer.ValueKind == JsonValueKind.Object) ?
+                ResponseExtractors.OptionalStringProperty(closer, "url")
+                : default).LastOrDefault(url => url is not null);
+        }
 
         LinkText = $"""
         <a href = "https://github.com/{organization}/{repository}/issues/{Number}">

--- a/DotNet.DocsTools/GitHubObjects/QuestPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestPullRequest.cs
@@ -48,5 +48,5 @@ public sealed record QuestPullRequest : QuestIssueOrPullRequest, IGitHubQueryRes
     public static QuestPullRequest FromJsonElement(JsonElement issueNode, QuestIssueOrPullRequestVariables variables) =>
         new(issueNode, variables.Organization, variables.Repository);
 
-    private QuestPullRequest(JsonElement issueNode, string organization, string repository) : base(issueNode, organization, repository) { }
+    private QuestPullRequest(JsonElement issueNode, string organization, string repository) : base(issueNode, organization, repository, false) { }
 }

--- a/DotnetDocsToolsTests/GraphQLProcessingTests/QuestIssueTests.cs
+++ b/DotnetDocsToolsTests/GraphQLProcessingTests/QuestIssueTests.cs
@@ -503,7 +503,7 @@ namespace DotnetDocsTools.Tests.GraphQLProcessingTests
             Assert.Equal(2023, points.CalendarYear);
             Assert.Equal("Dec", points.Month);
             Assert.Equal("🦔 Tiny (4h)", points.Size);
-            Assert.Equal("https://github.com/dotnet/docs/pull/38584", issue.ClosingPRUrl);
+            Assert.Null(issue.ClosingPRUrl);
         }
 
         [Fact]

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -76,12 +76,12 @@ public class QuestGitHubService(
         var issueQueryEnumerable = QueryIssuesOrPullRequests<QuestIssue>();
         await ProcessItems(issueQueryEnumerable);
         Console.WriteLine("-----   Finished processing issues.          --------");
-        //Console.WriteLine("     ----- Regenerating bearer token   ------");
+        Console.WriteLine("     ----- Regenerating bearer token   ------");
         await ghClient.RegenerateBearerToken();
-        //Console.WriteLine("-----   Starting processing pull requests.   --------");
-        //var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
-        //await ProcessItems(prQueryEnumerable);
-        //Console.WriteLine("-----   Finished processing pull requests.   --------");
+        Console.WriteLine("-----   Starting processing pull requests.   --------");
+        var prQueryEnumerable = QueryIssuesOrPullRequests<QuestPullRequest>();
+        await ProcessItems(prQueryEnumerable);
+        Console.WriteLine("-----   Finished processing pull requests.   --------");
 
         async Task ProcessItems(IAsyncEnumerable<QuestIssueOrPullRequest> items)
         {


### PR DESCRIPTION
Timeline items shouldn't be included in a PR query because looking for the "closing PR event" on a PR causes a circular graph.
