### PR TITLE
Try to auto detect .NET Framework projects

### DIFF
--- a/snippets5000/Snippets5000/Program.cs
+++ b/snippets5000/Snippets5000/Program.cs
@@ -224,7 +224,20 @@ class Program
                 {
                     Log.Write(2, $"Unable to load config file: {e1.StackTrace}");
                 }
-                
+            }
+
+            // Config not found, try and peek at the project to see if it's framework
+            else if (!projectPath.EndsWith("sln", StringComparison.OrdinalIgnoreCase))
+            {
+                string firstLine = File.ReadLines(projectPath).First();
+
+                if (firstLine.StartsWith("<project", StringComparison.OrdinalIgnoreCase)
+                    && firstLine.Contains("toolsversion", StringComparison.OrdinalIgnoreCase)
+                    && !firstLine.Contains("sdk=", StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.Write(2, "Detected .NET Framework project file. Switching to Visual Studio as the host.");
+                    config.Host = "visualstudio";
+                }
             }
 
             Log.Write(2, $"Mode: {config.Host}");

--- a/snippets5000/Snippets5000/Snippets5000.csproj
+++ b/snippets5000/Snippets5000/Snippets5000.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
-    <Version>4.1.0.0</Version>
+    <Version>4.2.0.0</Version>
     <AssemblyTitle>Snippets 5000</AssemblyTitle>
     <Authors>Andy De George</Authors>
     <Company>Microsoft</Company>


### PR DESCRIPTION
Snippets5000 will test to see if the project file being looked at is in the .NET Framework format, if it is, and no snippets config file was specified, it switches the build mode to Visual Studio.