### PR TITLE
The previous logic only worked for new issues

### DIFF
--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -384,9 +384,9 @@ public class QuestGitHubService(
             patchDocument.Add(assignPatch);
         }
         bool questItemOpen = questItem.State is not "Closed";
+        proposedQuestState = ghIssue.IsOpen ? "Committed" : "Closed";
         if (ghIssue.IsOpen != questItemOpen)
         {
-            proposedQuestState = ghIssue.IsOpen ? "Committed" : "Closed";
 
             // When the issue is opened or closed, 
             // update the description. That picks up any new


### PR DESCRIPTION
Set any updated issue to "committed" rather than "new".