### PR TITLE
Handle per-semester parents in Quest

### DIFF
--- a/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
@@ -7,6 +7,8 @@ public class QuestIteration
     public required string Name { get; init; }
     public required string Path { get; init; }
 
+    public bool IsInSemester(string semesterName) => Path.Contains(semesterName);
+
     public static QuestIteration? CurrentIteration(IEnumerable<QuestIteration> iterations)
     {
         var currentYear = int.Parse(DateTime.Now.ToString("yyyy"));

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -150,7 +150,7 @@ public class QuestWorkItem
         int defaultParentNode)
     {
         string areaPath = $"""{questClient.QuestProject}\{path}""";
-        int parentId = parentIdFromIssue(parentNodes, issue, defaultParentNode, allIterations);
+        int parentId = ParentIdFromIssue(parentNodes, issue, defaultParentNode, allIterations);
 
         List<JsonPatchDocument> patchDocument =
         [
@@ -410,7 +410,7 @@ public class QuestWorkItem
         IEnumerable<ParentForLabel> parentNodes,
         int defaultParentNode)
     {
-        int parentId = parentIdFromIssue(parentNodes, ghIssue, defaultParentNode, allIterations);
+        int parentId = ParentIdFromIssue(parentNodes, ghIssue, defaultParentNode, allIterations);
         string? ghAssigneeEmailAddress = await ghIssue.QueryAssignedMicrosoftEmailAddressAsync(ospoClient);
         AzDoIdentity? questAssigneeID = default;
         var proposedQuestState = questItem.State;
@@ -557,7 +557,7 @@ public class QuestWorkItem
         return newItem;
     }
 
-    static private int parentIdFromIssue(IEnumerable<ParentForLabel> parentNodes, QuestIssueOrPullRequest ghIssue, int defaultParentNode, IEnumerable<QuestIteration> allIterations)
+    static private int ParentIdFromIssue(IEnumerable<ParentForLabel> parentNodes, QuestIssueOrPullRequest ghIssue, int defaultParentNode, IEnumerable<QuestIteration> allIterations)
     {
         var iteration = ghIssue.LatestStoryPointSize()?.ProjectIteration(allIterations);
         

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -1,6 +1,6 @@
 ﻿namespace Quest2GitHub.Options;
 
-public record struct ParentForLabel(string Label, int ParentNodeId);
+public record struct ParentForLabel(string? Label, string? Semester, int ParentNodeId);
 
 public record struct LabelToTagMap(string Label, string Tag);
 

--- a/quest-config.json
+++ b/quest-config.json
@@ -6,5 +6,55 @@
     },
     "ImportTriggerLabel": ":world_map: reQUEST",
     "ImportedLabel": ":pushpin: seQUESTered",
-    "DefaultParentNode": 233488
+    "ParentNodes": [
+        {
+            "Semester": "Dilithium",
+            "Label": "user-feedback",
+            "ParentNodeId": 233465
+        },
+        {
+            "Semester": "Dilithium",
+            "Label": "sfi-ropc",
+            "ParentNodeId": 271716
+        },
+        {
+            "Semester": "Dilithium",
+            "ParentNodeId": 233488
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "sfi-admin",
+            "ParentNodeId": 271716
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "sfi-images",
+            "ParentNodeId": 286370
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "user-feedback",
+            "ParentNodeId": 233465
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "sfi-ropc",
+            "ParentNodeId": 271716
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "sfi-admin",
+            "ParentNodeId": 271716
+        },
+        {
+            "Semester": "Selenium",
+            "Label": "sfi-images",
+            "ParentNodeId": 286370
+        },
+        {
+            "Semester": "Selenium",
+            "ParentNodeId": 233488
+        }
+    ]
 }
+ 

--- a/quest-config.json
+++ b/quest-config.json
@@ -6,5 +6,15 @@
     },
     "ImportTriggerLabel": ":world_map: reQUEST",
     "ImportedLabel": ":pushpin: seQUESTered",
-    "DefaultParentNode": 233488
+    "ParentNodes": [
+        {
+            "Semester": "Dilithium",
+            "ParentNodeId": 233488
+        },
+        {
+            "Semester": "Selenium",
+            "ParentNodeId": 286035
+        }
+    ],
+    "DefaultParentNode": 286035
 }

--- a/quest-config.json
+++ b/quest-config.json
@@ -14,6 +14,10 @@
         {
             "Semester": "Selenium",
             "ParentNodeId": 286035
+        },
+        {
+            "Label": "user-feedback",
+            "ParentNodeId": 233465
         }
     ],
     "DefaultParentNode": 286035

--- a/quest-config.json
+++ b/quest-config.json
@@ -6,55 +6,5 @@
     },
     "ImportTriggerLabel": ":world_map: reQUEST",
     "ImportedLabel": ":pushpin: seQUESTered",
-    "ParentNodes": [
-        {
-            "Semester": "Dilithium",
-            "Label": "user-feedback",
-            "ParentNodeId": 233465
-        },
-        {
-            "Semester": "Dilithium",
-            "Label": "sfi-ropc",
-            "ParentNodeId": 271716
-        },
-        {
-            "Semester": "Dilithium",
-            "ParentNodeId": 233488
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "sfi-admin",
-            "ParentNodeId": 271716
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "sfi-images",
-            "ParentNodeId": 286370
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "user-feedback",
-            "ParentNodeId": 233465
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "sfi-ropc",
-            "ParentNodeId": 271716
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "sfi-admin",
-            "ParentNodeId": 271716
-        },
-        {
-            "Semester": "Selenium",
-            "Label": "sfi-images",
-            "ParentNodeId": 286370
-        },
-        {
-            "Semester": "Selenium",
-            "ParentNodeId": 233488
-        }
-    ]
+    "DefaultParentNode": 233488
 }
- 

--- a/quest-config.json
+++ b/quest-config.json
@@ -14,11 +14,7 @@
         {
             "Semester": "Selenium",
             "ParentNodeId": 286035
-        },
-        {
-            "Label": "user-feedback",
-            "ParentNodeId": 233465
         }
-    ],
+     ],
     "DefaultParentNode": 286035
 }


### PR DESCRIPTION
There are three sets of changes here:

1. A bit of refactoring to keep the communications with Azure DevOps in one place.
2. Expand the config object to include semesters on any parentNode object. Now, the `semester` and `Label` tags are both optional:
   - If `Label` is null, the parentNode becomes the default node for that semester.
   - if `semester` is null, this parentNode is used for all semesters. This is primarily for backwards compatibility
3. Read the updated config and use that info to set the correct parent.