### PR TITLE
update net8 target to net8.0

### DIFF
--- a/DotNet.DocsTools/DotNet.DocsTools.csproj
+++ b/DotNet.DocsTools/DotNet.DocsTools.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>2.1.0.0</AssemblyVersion>

--- a/DotnetDocsToolsTests/DotnetDocsTools.Tests.csproj
+++ b/DotnetDocsToolsTests/DotnetDocsTools.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
+++ b/GitHub.RepositoryExplorer.Client/GitHub.RepositoryExplorer.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>1e8b5bf8-1a2d-446d-9cd3-48609334c53f</UserSecretsId>

--- a/GitHub.RepositoryExplorer.Functions/GitHub.RepositoryExplorer.Functions.csproj
+++ b/GitHub.RepositoryExplorer.Functions/GitHub.RepositoryExplorer.Functions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>

--- a/GitHub.RepositoryExplorer.Models/GitHub.RepositoryExplorer.Models.csproj
+++ b/GitHub.RepositoryExplorer.Models/GitHub.RepositoryExplorer.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/GitHub.RepositoryExplorer.Services/GitHub.RepositoryExplorer.Services.csproj
+++ b/GitHub.RepositoryExplorer.Services/GitHub.RepositoryExplorer.Services.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>

--- a/GitHub.RepositoryExplorer.WebApi/GitHub.RepositoryExplorer.WebApi.csproj
+++ b/GitHub.RepositoryExplorer.WebApi/GitHub.RepositoryExplorer.WebApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>7d02fdaa-bfe2-4c8f-aee9-77abea14057c</UserSecretsId>

--- a/IssueCloser/IssueCloser.csproj
+++ b/IssueCloser/IssueCloser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<AssemblyVersion>2.0.0.0</AssemblyVersion>

--- a/WhatsNew.Cli/WhatsNew.Cli.csproj
+++ b/WhatsNew.Cli/WhatsNew.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	  <Nullable>enable</Nullable>
 	  <ImplicitUsings>enable</ImplicitUsings>
 	  <OutputType>Exe</OutputType>

--- a/WhatsNew.Infrastructure.Tests/WhatsNew.Infrastructure.Tests.csproj
+++ b/WhatsNew.Infrastructure.Tests/WhatsNew.Infrastructure.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 	<Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<IsPackable>false</IsPackable>

--- a/WhatsNew.Infrastructure/WhatsNew.Infrastructure.csproj
+++ b/WhatsNew.Infrastructure/WhatsNew.Infrastructure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 	<ImplicitUsings>enable</ImplicitUsings>
     <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>

--- a/XmlDocConflictResolver/XmlDocConflictResolver.csproj
+++ b/XmlDocConflictResolver/XmlDocConflictResolver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/actions/dependabot-bot/src/dependabot-bot/dependabot-bot.csproj
+++ b/actions/dependabot-bot/src/dependabot-bot/dependabot-bot.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Description>A .NET tool for generating dependabot config files for .NET.</Description>

--- a/actions/docs-verifier/src/ActionRunner/ActionRunner.csproj
+++ b/actions/docs-verifier/src/ActionRunner/ActionRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <nullable>enable</nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/actions/docs-verifier/src/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
+++ b/actions/docs-verifier/src/BuildVerifier.IO.Abstractions/BuildVerifier.IO.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/actions/docs-verifier/src/GitHub/GitHub.csproj
+++ b/actions/docs-verifier/src/GitHub/GitHub.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownLinksVerifier.csproj
+++ b/actions/docs-verifier/src/MarkdownLinksVerifier/MarkdownLinksVerifier.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/actions/docs-verifier/src/RedirectionVerifier/RedirectionVerifier.csproj
+++ b/actions/docs-verifier/src/RedirectionVerifier/RedirectionVerifier.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/actions/docs-verifier/tests/GitHub.UnitTests/GitHub.UnitTests.csproj
+++ b/actions/docs-verifier/tests/GitHub.UnitTests/GitHub.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
 

--- a/actions/docs-verifier/tests/MarkdownLinksVerifier/MarkdownLinksVerifier.UnitTests.csproj
+++ b/actions/docs-verifier/tests/MarkdownLinksVerifier/MarkdownLinksVerifier.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/actions/sequester/ImportIssues/ImportIssues.csproj
+++ b/actions/sequester/ImportIssues/ImportIssues.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/actions/sequester/Quest2GitHub.Tests/Quest2GitHub.Tests.csproj
+++ b/actions/sequester/Quest2GitHub.Tests/Quest2GitHub.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/actions/sequester/Quest2GitHub/Quest2GitHub.csproj
+++ b/actions/sequester/Quest2GitHub/Quest2GitHub.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyVersion>2.0.0.1</AssemblyVersion>

--- a/cleanrepo/CleanRepo.csproj
+++ b/cleanrepo/CleanRepo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <nullable>enable</nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>

--- a/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
+++ b/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/snippets5000/Snippets5000/Snippets5000.csproj
+++ b/snippets5000/Snippets5000/Snippets5000.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
`net8` is not a standard target framework name which should not be used, update to the standard `net8.0`

![image](https://github.com/user-attachments/assets/66f69369-a714-4771-b858-2cfc76728a56)


https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md#what-about-net-10