### PR TITLE
Add Microsoft.IO.Redist package

### DIFF
--- a/PackageIndexer/PackageFilter.cs
+++ b/PackageIndexer/PackageFilter.cs
@@ -78,6 +78,7 @@ public sealed class PackageFilter(IEnumerable<PackageFilterExpression> includes,
         [
             PackageFilterExpression.Parse("Microsoft.Bcl.*"),
             PackageFilterExpression.Parse("Microsoft.Extensions.*"),
+            PackageFilterExpression.Parse("Microsoft.IO.Redist"),
             PackageFilterExpression.Parse("Microsoft.Win32.*"),
             PackageFilterExpression.Parse("System.*"),
         ],


### PR DESCRIPTION
Add Microsoft.IO.Redist package to be ingested for docs per @carlossanlop.

"This assembly is just a wrapper for System.IO classes so that Roslyn and others can use System.IO APIs without hitting some annoying problems."