### PR TITLE
Fix msbuild error in CleanRepo

### DIFF
--- a/cleanrepo/CleanRepo.csproj
+++ b/cleanrepo/CleanRepo.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
     <PackageReference Include="Tesseract" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Build" Version="17.12.6" />
+    <PackageReference Include="Microsoft.Build" Version="17.11.4" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appSettings.json">


### PR DESCRIPTION
Error was:

Unhandled exception. System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build.Framework, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.