### PR TITLE
Refactor logic to construct the work item properties from the GitHub issue and associated projects

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -117,7 +117,6 @@ internal class Program
                 options.AzureDevOps.AreaPath,
                 options.ImportTriggerLabel,
                 options.ImportedLabel,
-                options.DefaultParentNode,
                 options.ParentNodes,
                 options.WorkItemTags);
     }

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -1,0 +1,608 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Runtime.ConstrainedExecution;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DotNet.DocsTools.GitHubObjects;
+using DotNet.DocsTools.GraphQLQueries;
+using Org.BouncyCastle.Bcpg.Sig;
+using Quest2GitHub.Models;
+using static System.Net.Mime.MediaTypeNames;
+
+namespace Quest2GitHub.Tests;
+
+public class BuildExtendedPropertiesTests
+{
+    private static QuestIteration[] _allIterations =
+    [
+        new() { Id =  1, Identifier = Guid.Parse("11111111-1111-1111-1111-111111111111"), Name = "Future", Path = """Content\Future""" },
+        new() { Id =  2, Identifier = Guid.Parse("22222222-2222-2222-2222-222222222222"), Name = "04 Apr", Path = """Content\Dilithium\FY24Q4\04 Apr""" },
+        new() { Id =  3, Identifier = Guid.Parse("33333333-3333-3333-3333-333333333333"), Name = "05 May", Path = """Content\Dilithium\FY24Q4\05 May""" },
+        new() { Id =  4, Identifier = Guid.Parse("44444444-4444-4444-4444-444444444444"), Name = "06 Jun", Path = """Content\Dilithium\FY24Q4\06 Jun""" },
+        new() { Id =  5, Identifier = Guid.Parse("55555555-5555-5555-5555-555555555555"), Name = "07 Jul", Path = """Content\Dilithium\FY25Q1\07 Jul""" },
+        new() { Id =  6, Identifier = Guid.Parse("66666666-6666-6666-6666-666666666666"), Name = "08 Aug", Path = """Content\Dilithium\FY25Q1\08 Aug""" },
+        new() { Id =  7, Identifier = Guid.Parse("77777777-7777-7777-7777-777777777777"), Name = "09 Sep", Path = """Content\Dilithium\FY25Q1\09 Sep""" },
+        new() { Id =  8, Identifier = Guid.Parse("88888888-8888-8888-8888-888888888888"), Name = "10 Oct", Path = """Content\Selenium\FY25Q2\10 Oct""" },
+        new() { Id =  9, Identifier = Guid.Parse("99999999-9999-9999-9999-999999999999"), Name = "11 Nov", Path = """Content\Selenium\FY25Q2\11 Nov""" },
+        new() { Id = 10, Identifier = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"), Name = "12 Dev", Path = """Content\Selenium\FY25Q2\12 Dec""" },
+        new() { Id = 11, Identifier = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"), Name = "01 Jan", Path = """Content\Selenium\FY25Q3\01 Jan""" },
+        new() { Id = 12, Identifier = Guid.Parse("cccccccc-cccc-cccc-cccc-cccccccccccc"), Name = "02 Feb", Path = """Content\Selenium\FY25Q3\02 Feb""" },
+        new() { Id = 13, Identifier = Guid.Parse("dddddddd-dddd-dddd-dddd-dddddddddddd"), Name = "03 Mar", Path = """Content\Selenium\FY25Q3\03 Mar""" }
+    ];
+    private static LabelToTagMap[] _tagMap =
+    [
+        new () { Label = ":checkered_flag: Release: .NET 9", Tag = "new-feature" },
+        new () { Label = labelForTag, Tag = "content-curation" },
+    ];
+
+    private static ParentForLabel[] _parentMap =
+    [
+        new () { Label = labelWithParent, Semester = "Selenium", ParentNodeId = 1 },
+        new () { Label = null, Semester = "Selenium", ParentNodeId = 2 },
+        new () { Label = labelWithParent, Semester = "Dilithium", ParentNodeId = 11 },
+        new () { Label = null, Semester = "Dilithium", ParentNodeId = 22 }
+    ];
+    private const int _defaultParentId = 33;
+
+    private const string labelForTag = "okr-curation";
+    private const string labelWithoutTag = "enhancement";
+    private const string labelWithParent = "user-feedback";
+    private const string labelWithoutParent = "bug";
+
+
+    private const string PastProject = """
+      {
+        "fieldValues": {
+          "nodes": [
+            {
+                "field": {
+                "name": "Status"
+                },
+                "name": "Slipped"
+            },
+            {
+                "field": {
+                "name": "Priority"
+                },
+                "name": "🏔 Pri1"
+            },
+            {
+                "field": {
+                "name": "Size"
+                },
+                "name": "🐂 Medium (3-5d)"
+            }
+            ]
+        },
+        "project": {
+            "title": "dotnet/docs July 2024 Sprint"
+        }
+      }
+      """;
+
+    private const string AnotherPastProject = """
+      {
+        "fieldValues": {
+          "nodes": [
+            {
+                "field": {
+                "name": "Status"
+                },
+                "name": "Slipped"
+            },
+            {
+                "field": {
+                "name": "Priority"
+                },
+                "name": "🏔 Pri1"
+            },
+            {
+                "field": {
+                "name": "Size"
+                },
+                "name": "🐂 Medium (3-5d)"
+            }
+            ]
+        },
+        "project": {
+            "title": "dotnet/docs October 2024 Sprint"
+        }
+      }
+      """;
+    private const string FutureProject = """
+      {
+        "fieldValues": {
+          "nodes": [
+            {
+                "field": {
+                "name": "Status"
+                },
+                "name": "Ready"
+            },
+            {
+                "field": {
+                "name": "Priority"
+                },
+                "name": "🏔 Pri1"
+            },
+            {
+                "field": {
+                "name": "Size"
+                },
+                "name": "🐂 Medium (3-5d)"
+            }
+            ]
+        },
+        "project": {
+            "title": "dotnet/docs March 2025 Sprint"
+        }
+      }
+      """;
+
+    private const string SingleIssueFutureProject = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{FutureProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithoutParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string SingleIssueFutureProjectWithTags = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{FutureProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelForTag}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": "{{labelWithoutTag}}",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string SingleIssueFutureProjectWithParentLabel = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{FutureProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": "{{labelWithoutTag}}",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string MultipleFutureProjects = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{PastProject}},
+          {{FutureProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithoutParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string SingleIssuePastProject = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{PastProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string MultipleIssuePastProject = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{AnotherPastProject}},
+          {{PastProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelForTag}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+    private const string NoProject = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "OPEN",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": []
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+
+    [Fact]
+    public static void BuildExtensionForFutureProject()
+    {
+        var extendedProperties = CreateIssueObject(SingleIssueFutureProject);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
+        Assert.False(extendedProperties.IsPastIteration);
+        Assert.Equal("Mar", extendedProperties.Month);
+        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Empty(extendedProperties.Tags);
+
+        // TODO: Add Parent (2)
+    }
+
+    [Fact]
+    public static void BuildExtensionForFutureProjectWithTag()
+    {
+        var extendedProperties = CreateIssueObject(SingleIssueFutureProjectWithTags);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
+        Assert.False(extendedProperties.IsPastIteration);
+        Assert.Equal("Mar", extendedProperties.Month);
+        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Equal(["content-curation"], extendedProperties.Tags);
+
+        // TODO: Add Parent (2)
+    }
+
+    [Fact]
+    public static void BuildExtensionForFutureProjectWithParent()
+    {
+        var extendedProperties = CreateIssueObject(SingleIssueFutureProjectWithParentLabel);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
+        Assert.False(extendedProperties.IsPastIteration);
+        Assert.Equal("Mar", extendedProperties.Month);
+        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Empty(extendedProperties.Tags);
+
+        // TODO: Add Parent (1)
+    }
+
+    [Fact]
+    public static void BuildExtensionForMultipleFutureProject()
+    {
+        var extendedProperties = CreateIssueObject(MultipleFutureProjects);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
+        Assert.False(extendedProperties.IsPastIteration);
+        Assert.Equal("Mar", extendedProperties.Month);
+        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Empty(extendedProperties.Tags);
+
+        // TODO: Add Parent (1)
+    }
+
+    [Fact]
+    public static void BuildExtensionForSinglePastProject()
+    {
+        var extendedProperties = CreateIssueObject(SingleIssuePastProject);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("07 Jul", extendedProperties.LatestIteration?.Name);
+        Assert.True(extendedProperties.IsPastIteration);
+        Assert.Equal("Jul", extendedProperties.Month);
+        Assert.Equal(2024, extendedProperties.CalendarYear);
+        Assert.Empty(extendedProperties.Tags);
+
+        // TODO: Add Parent (null)
+    }
+
+    [Fact]
+    public static void BuildExtensionForMultiplePastProject()
+    {
+        var extendedProperties = CreateIssueObject(MultipleIssuePastProject);
+
+        // Check each property:
+        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("10 Oct", extendedProperties.LatestIteration?.Name);
+        Assert.True(extendedProperties.IsPastIteration);
+        Assert.Equal("Oct", extendedProperties.Month);
+        Assert.Equal(2024, extendedProperties.CalendarYear);
+        Assert.Equal(["content-curation"], extendedProperties.Tags);
+
+        // TODO: Add Parent (null)
+    }
+
+    [Fact]
+    public static void BuildExtensionForNoProject()
+    {
+        var extendedProperties = CreateIssueObject(NoProject);
+
+        // Check each property:
+        Assert.Equal("Unknown", extendedProperties.GitHubSize);
+        Assert.Equal(null, extendedProperties.StoryPoints);
+        Assert.Equal(null, extendedProperties.Priority);
+        Assert.Equal(null, extendedProperties.LatestIteration?.Name);
+        Assert.False(extendedProperties.IsPastIteration);
+        Assert.Equal("Unknown", extendedProperties.Month);
+        Assert.Equal(0, extendedProperties.CalendarYear);
+        Assert.Empty(extendedProperties.Tags);
+
+        // TODO: Add Parent (null)
+    }
+
+
+    private static ExtendedIssueProperties CreateIssueObject(string jsonDocument)
+    {
+        var variables = new QuestIssueOrPullRequestVariables
+        {
+            Organization = "dotnet",
+            Repository = "docs",
+            issueNumber = 1111
+        };
+        JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
+        return QuestIssue.FromJsonElement(element, variables).ExtendedProperties(_allIterations, _tagMap);
+    }
+
+}

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -532,7 +532,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("07 Jul", extendedProperties.LatestIteration?.Name);
+        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
         Assert.True(extendedProperties.IsPastIteration);
         Assert.Equal("Jul", extendedProperties.Month);
         Assert.Equal(2024, extendedProperties.CalendarYear);
@@ -549,7 +549,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("10 Oct", extendedProperties.LatestIteration?.Name);
+        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
         Assert.True(extendedProperties.IsPastIteration);
         Assert.Equal("Oct", extendedProperties.Month);
         Assert.Equal(2024, extendedProperties.CalendarYear);
@@ -566,7 +566,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Unknown", extendedProperties.GitHubSize);
         Assert.Equal(null, extendedProperties.StoryPoints);
         Assert.Equal(null, extendedProperties.Priority);
-        Assert.Equal(null, extendedProperties.LatestIteration?.Name);
+        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
         Assert.False(extendedProperties.IsPastIteration);
         Assert.Equal("Unknown", extendedProperties.Month);
         Assert.Equal(0, extendedProperties.CalendarYear);

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -729,7 +729,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
-    private static ExtendedIssueProperties CreateIssueObject(string jsonDocument)
+    private static WorkItemProperties CreateIssueObject(string jsonDocument)
     {
         var variables = new QuestIssueOrPullRequestVariables
         {
@@ -738,7 +738,7 @@ public class BuildExtendedPropertiesTests
             issueNumber = 1111
         };
         JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
-        return new ExtendedIssueProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap);
+        return new WorkItemProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap);
     }
 
 }

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -1,17 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.Compression;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Runtime.ConstrainedExecution;
-using System.Text;
-using System.Text.Json;
-using System.Threading.Tasks;
+﻿using System.Text.Json;
 using DotNet.DocsTools.GitHubObjects;
-using DotNet.DocsTools.GraphQLQueries;
-using Org.BouncyCastle.Bcpg.Sig;
 using Quest2GitHub.Models;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace Quest2GitHub.Tests;
 
@@ -480,8 +469,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Mar", extendedProperties.Month);
         Assert.Equal(2025, extendedProperties.CalendarYear);
         Assert.Empty(extendedProperties.Tags);
-
-        // TODO: Add Parent (2)
+        Assert.Equal(2, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -498,8 +486,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Mar", extendedProperties.Month);
         Assert.Equal(2025, extendedProperties.CalendarYear);
         Assert.Equal(["content-curation"], extendedProperties.Tags);
-
-        // TODO: Add Parent (2)
+        Assert.Equal(2, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -516,8 +503,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Mar", extendedProperties.Month);
         Assert.Equal(2025, extendedProperties.CalendarYear);
         Assert.Empty(extendedProperties.Tags);
-
-        // TODO: Add Parent (1)
+        Assert.Equal(1, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -534,8 +520,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Mar", extendedProperties.Month);
         Assert.Equal(2025, extendedProperties.CalendarYear);
         Assert.Empty(extendedProperties.Tags);
-
-        // TODO: Add Parent (1)
+        Assert.Equal(2, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -552,8 +537,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Jul", extendedProperties.Month);
         Assert.Equal(2024, extendedProperties.CalendarYear);
         Assert.Empty(extendedProperties.Tags);
-
-        // TODO: Add Parent (null)
+        Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -570,8 +554,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Oct", extendedProperties.Month);
         Assert.Equal(2024, extendedProperties.CalendarYear);
         Assert.Equal(["content-curation"], extendedProperties.Tags);
-
-        // TODO: Add Parent (null)
+        Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -588,8 +571,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Unknown", extendedProperties.Month);
         Assert.Equal(0, extendedProperties.CalendarYear);
         Assert.Empty(extendedProperties.Tags);
-
-        // TODO: Add Parent (null)
+        Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
 
@@ -602,7 +584,7 @@ public class BuildExtendedPropertiesTests
             issueNumber = 1111
         };
         JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
-        return QuestIssue.FromJsonElement(element, variables).ExtendedProperties(_allIterations, _tagMap);
+        return QuestIssue.FromJsonElement(element, variables).ExtendedProperties(_allIterations, _tagMap, _parentMap);
     }
 
 }

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -178,6 +178,52 @@ public class BuildExtendedPropertiesTests
     }        
     """;
 
+    private const string SingleActiveIssueClosed= $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "CLOSED",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{FutureProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithoutParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
     private const string SingleIssueFutureProjectWithTags = $$"""
     {
       "id": "I_kwDOFn2dfM6YkX0J",
@@ -363,6 +409,53 @@ public class BuildExtendedPropertiesTests
     }        
     """;
 
+    private const string SingleClosedIssuePastProject = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "CLOSED",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": [
+          {{PastProject}}
+        ]
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
+
+
     private const string MultipleIssuePastProject = $$"""
     {
       "id": "I_kwDOFn2dfM6YkX0J",
@@ -454,6 +547,49 @@ public class BuildExtendedPropertiesTests
     }        
     """;
 
+    private const string NoProjectClosed = $$"""
+    {
+      "id": "I_kwDOFn2dfM6YkX0J",
+      "number": 1111,
+      "title": "This is an issue",
+      "state": "CLOSED",
+      "author": {
+        "login": "BillWagner",
+        "name": "Bill Wagner"
+      },
+      "timelineItems": {
+        "nodes": []
+      },
+      "projectItems": {
+        "nodes": []
+      },
+      "bodyHTML": "<p dir=\"auto\">This is a bad, bad, thing.</p>",
+      "body": "This is a bad, bad, thing.",
+      "assignees": {
+        "nodes": [
+          {
+            "login": "BillWagner",
+            "name": "Bill Wagner"
+          }
+        ]
+      },
+      "labels": {
+        "nodes": [
+          {
+            "name": "{{labelWithParent}}",
+            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
+          },
+          {
+            "name": ":pushpin: seQUESTered",
+            "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          }
+        ]
+      },
+      "comments": {
+        "nodes": []
+      }
+    }        
+    """;
 
     [Fact]
     public static void BuildExtensionForFutureProject()
@@ -461,30 +597,37 @@ public class BuildExtendedPropertiesTests
         var extendedProperties = CreateIssueObject(SingleIssueFutureProject);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
-        Assert.False(extendedProperties.IsPastIteration);
-        Assert.Equal("Mar", extendedProperties.Month);
-        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Selenium\\FY25Q3\\03 Mar", extendedProperties.IterationPath);
+        Assert.Equal("Committed", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
         Assert.Equal(2, extendedProperties.ParentNodeId);
     }
 
+    [Fact]
+    public static void BuildExtensionForClosedIssueInFutureProject()
+    {
+        var extendedProperties = CreateIssueObject(SingleActiveIssueClosed);
+
+        // Check each property:
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("Content\\Selenium\\FY25Q3\\03 Mar", extendedProperties.IterationPath);
+        Assert.Equal("Closed", extendedProperties.WorkItemState);
+        Assert.Empty(extendedProperties.Tags);
+        Assert.Equal(2, extendedProperties.ParentNodeId);
+    }
     [Fact]
     public static void BuildExtensionForFutureProjectWithTag()
     {
         var extendedProperties = CreateIssueObject(SingleIssueFutureProjectWithTags);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
-        Assert.False(extendedProperties.IsPastIteration);
-        Assert.Equal("Mar", extendedProperties.Month);
-        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Selenium\\FY25Q3\\03 Mar", extendedProperties.IterationPath);
+        Assert.Equal("Committed", extendedProperties.WorkItemState);
         Assert.Equal(["content-curation"], extendedProperties.Tags);
         Assert.Equal(2, extendedProperties.ParentNodeId);
     }
@@ -495,13 +638,10 @@ public class BuildExtendedPropertiesTests
         var extendedProperties = CreateIssueObject(SingleIssueFutureProjectWithParentLabel);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
-        Assert.False(extendedProperties.IsPastIteration);
-        Assert.Equal("Mar", extendedProperties.Month);
-        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Selenium\\FY25Q3\\03 Mar", extendedProperties.IterationPath);
+        Assert.Equal("Committed", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
         Assert.Equal(1, extendedProperties.ParentNodeId);
     }
@@ -512,13 +652,10 @@ public class BuildExtendedPropertiesTests
         var extendedProperties = CreateIssueObject(MultipleFutureProjects);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("03 Mar", extendedProperties.LatestIteration?.Name);
-        Assert.False(extendedProperties.IsPastIteration);
-        Assert.Equal("Mar", extendedProperties.Month);
-        Assert.Equal(2025, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Selenium\\FY25Q3\\03 Mar", extendedProperties.IterationPath);
+        Assert.Equal("Committed", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
         Assert.Equal(2, extendedProperties.ParentNodeId);
     }
@@ -529,30 +666,37 @@ public class BuildExtendedPropertiesTests
         var extendedProperties = CreateIssueObject(SingleIssuePastProject);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
-        Assert.True(extendedProperties.IsPastIteration);
-        Assert.Equal("Jul", extendedProperties.Month);
-        Assert.Equal(2024, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
         Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
+    [Fact]
+    public static void BuildExtensionForClosedIsssueSinglePastProject()
+    {
+        var extendedProperties = CreateIssueObject(SingleClosedIssuePastProject);
+
+        // Check each property:
+        Assert.Equal(5, extendedProperties.StoryPoints);
+        Assert.Equal(2, extendedProperties.Priority);
+        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("Closed", extendedProperties.WorkItemState);
+        Assert.Empty(extendedProperties.Tags);
+        Assert.Equal(0, extendedProperties.ParentNodeId);
+    }
     [Fact]
     public static void BuildExtensionForMultiplePastProject()
     {
         var extendedProperties = CreateIssueObject(MultipleIssuePastProject);
 
         // Check each property:
-        Assert.Equal("🐂 Medium (3-5d)", extendedProperties.GitHubSize);
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
-        Assert.True(extendedProperties.IsPastIteration);
-        Assert.Equal("Oct", extendedProperties.Month);
-        Assert.Equal(2024, extendedProperties.CalendarYear);
+        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Equal(["content-curation"], extendedProperties.Tags);
         Assert.Equal(0, extendedProperties.ParentNodeId);
     }
@@ -563,17 +707,27 @@ public class BuildExtendedPropertiesTests
         var extendedProperties = CreateIssueObject(NoProject);
 
         // Check each property:
-        Assert.Equal("Unknown", extendedProperties.GitHubSize);
-        Assert.Equal(null, extendedProperties.StoryPoints);
-        Assert.Equal(null, extendedProperties.Priority);
-        Assert.Equal("Future", extendedProperties.LatestIteration?.Name);
-        Assert.False(extendedProperties.IsPastIteration);
-        Assert.Equal("Unknown", extendedProperties.Month);
-        Assert.Equal(0, extendedProperties.CalendarYear);
+        Assert.Equal(0, extendedProperties.StoryPoints);
+        Assert.Equal(-1, extendedProperties.Priority);
+        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
         Assert.Equal(0, extendedProperties.ParentNodeId);
     }
 
+    [Fact]
+    public static void BuildExtensionForNoProjectClosed()
+    {
+        var extendedProperties = CreateIssueObject(NoProjectClosed);
+
+        // Check each property:
+        Assert.Equal(0, extendedProperties.StoryPoints);
+        Assert.Equal(-1, extendedProperties.Priority);
+        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("Closed", extendedProperties.WorkItemState);
+        Assert.Empty(extendedProperties.Tags);
+        Assert.Equal(0, extendedProperties.ParentNodeId);
+    }
 
     private static ExtendedIssueProperties CreateIssueObject(string jsonDocument)
     {
@@ -584,7 +738,7 @@ public class BuildExtendedPropertiesTests
             issueNumber = 1111
         };
         JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
-        return QuestIssue.FromJsonElement(element, variables).ExtendedProperties(_allIterations, _tagMap, _parentMap);
+        return new ExtendedIssueProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap);
     }
 
 }

--- a/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/ImportOptionsTests.cs
@@ -16,7 +16,6 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal(":world_map: reQUEST", actual.ImportTriggerLabel);
         Assert.Equal(":pushpin: seQUESTered", actual.ImportedLabel);
-        Assert.Equal(0, actual.DefaultParentNode);
         Assert.Empty(actual.ParentNodes);
 
         // API keys object
@@ -71,7 +70,6 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal("trigger-import", actual.ImportTriggerLabel);
         Assert.Equal("imported", actual.ImportedLabel);
-        Assert.Equal(228485, actual.DefaultParentNode);
         Assert.Equal(199082, actual.ParentNodes.Single(p => p.Label == "okr-health").ParentNodeId);
         Assert.Equal(227484, actual.ParentNodes.Single(p => p.Label == "dotnet-csharp/svc").ParentNodeId);
 
@@ -167,7 +165,6 @@ public class ImportOptionsTests
         // Top-level options
         Assert.Equal("trigger-label", actual.ImportTriggerLabel);
         Assert.Equal("imported-label", actual.ImportedLabel);
-        Assert.Equal(0, actual.DefaultParentNode);
         Assert.Empty(actual.ParentNodes);
 
         // Azure DevOps nested options

--- a/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Extensions/ImportOptionsExtensions.cs
@@ -81,7 +81,6 @@ public static class ImportOptionsExtensions
         Console.WriteLine($"  options.AzureDevOps.Org = \"{options?.AzureDevOps?.Org}\"");
         Console.WriteLine($"  options.AzureDevOps.Project = \"{options?.AzureDevOps?.Project}\"");
         Console.WriteLine($"  options.AzureDevOps.AreaPath = \"{options?.AzureDevOps?.AreaPath}\"");
-        Console.WriteLine($"  options.DefaultParentNode = \"{options?.DefaultParentNode}\"");
         Console.WriteLine($"  options.ParentNodes:");
         foreach (var node in options?.ParentNodes ?? Enumerable.Empty<ParentForLabel>())
         {

--- a/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
@@ -15,10 +15,13 @@ public record ExtendedIssueProperties(
     string GitHubSize, // The size in GitHub
     int? StoryPoints, // The points in AzDo
     int? Priority, // The priority in AzDo
-    QuestIteration? LatestIteration, // The latest iteration attached to this issue. If no iteration, set to current iteration.
+    QuestIteration LatestIteration, // The latest iteration attached to this issue. If no iteration, set to current iteration.
     // Set this to the "future" iteration as well, if that's the correct location.
     bool IsPastIteration,
     string Month,
     int CalendarYear,
     IEnumerable<string> Tags,
-    int ParentNodeId);
+    int ParentNodeId)
+{
+    public string IterationPath => LatestIteration.Path;
+}

--- a/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
@@ -20,4 +20,5 @@ public record ExtendedIssueProperties(
     bool IsPastIteration,
     string Month,
     int CalendarYear,
-    IEnumerable<string> Tags);
+    IEnumerable<string> Tags,
+    int ParentNodeId);

--- a/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
@@ -1,0 +1,23 @@
+﻿namespace Quest2GitHub.Models;
+
+/// <summary>
+/// Extended properties for a Quest issue.
+/// </summary>
+/// <remarks>
+/// We generally need the same properties for any GitHub issue
+/// or pull request to add it to Azure DevOps. So, build one
+/// constructor that creates them.
+///
+/// TODO:  REFACTOR SO dotted properties aren't stored directly. Put the IterationSize object
+/// in this type and add readonly properties.
+/// </remarks>
+public record ExtendedIssueProperties(
+    string GitHubSize, // The size in GitHub
+    int? StoryPoints, // The points in AzDo
+    int? Priority, // The priority in AzDo
+    QuestIteration? LatestIteration, // The latest iteration attached to this issue. If no iteration, set to current iteration.
+    // Set this to the "future" iteration as well, if that's the correct location.
+    bool IsPastIteration,
+    string Month,
+    int CalendarYear,
+    IEnumerable<string> Tags);

--- a/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
@@ -1,4 +1,6 @@
-﻿namespace Quest2GitHub.Models;
+﻿using DotNet.DocsTools.GitHubObjects;
+
+namespace Quest2GitHub.Models;
 
 /// <summary>
 /// Extended properties for a Quest issue.
@@ -6,22 +8,172 @@
 /// <remarks>
 /// We generally need the same properties for any GitHub issue
 /// or pull request to add it to Azure DevOps. So, build one
-/// constructor that creates them.
-///
-/// TODO:  REFACTOR SO dotted properties aren't stored directly. Put the IterationSize object
-/// in this type and add readonly properties.
+/// type that holds them. when this type is constructed, it uses
+/// the issue or pull request to along with some environment settings
+/// to compute the values that should be set on the associated work
+/// item. This type centralizes the algorithms to determine the
+/// Azure Dev Ops properties for an issue based on the issue
+/// properties, the project(s) that the issue is a member of
+/// and the environment settings.
 /// </remarks>
-public record ExtendedIssueProperties(
-    string GitHubSize, // The size in GitHub
-    int? StoryPoints, // The points in AzDo
-    int? Priority, // The priority in AzDo
-    QuestIteration LatestIteration, // The latest iteration attached to this issue. If no iteration, set to current iteration.
-    // Set this to the "future" iteration as well, if that's the correct location.
-    bool IsPastIteration,
-    string Month,
-    int CalendarYear,
-    IEnumerable<string> Tags,
-    int ParentNodeId)
+public class ExtendedIssueProperties
 {
-    public string IterationPath => LatestIteration.Path;
+    public ExtendedIssueProperties (QuestIssueOrPullRequest issue,
+        IEnumerable<QuestIteration> iterations,
+        IEnumerable<LabelToTagMap> tags,
+        IEnumerable<ParentForLabel> parentNodes)
+    {
+        StoryPointSize? storySize = LatestStoryPointSize(issue);
+        StoryPoints = QuestStoryPoint(storySize) ?? 0;
+        Priority = GetPriority(issue, storySize) ?? -1;
+        var latestIteration = storySize?.ProjectIteration(iterations) ?? QuestIteration.FutureIteration(iterations);
+        bool IsBackLog = storySize?.IsPastIteration ?? true;
+
+        if (IsBackLog)
+        {
+            latestIteration = QuestIteration.FutureIteration(iterations);
+        }
+
+        WorkItemState = (issue.IsOpen, IsBackLog) switch
+        {
+            (false, _) => "Closed",
+            (true, false) => "Committed",
+            (_) => "New"
+        };
+        IterationPath = latestIteration.Path;
+
+        ParentNodeId = 0;
+
+        if (!IsBackLog)
+        {
+            foreach (ParentForLabel pair in parentNodes)
+            {
+                if (issue.Labels.Any(l => l.Name == pair.Label) || (pair.Label is null))
+                {
+                    if ((pair.Semester is null) || (latestIteration.IsInSemester(pair.Semester) is true))
+                    {
+                        ParentNodeId = pair.ParentNodeId;
+                        break;
+                    }
+                }
+            }
+        }
+
+        Tags = WorkItemTagsForIssue(issue, tags);
+
+        string month = storySize?.Month ?? "Unknown";
+        int calendarYear = storySize?.CalendarYear ?? 0;
+        string gitHubSize = storySize?.Size ?? "Unknown";
+        IssueLogString = $"GH sprint: {month}-{calendarYear}, size: {gitHubSize}, Iteration: {IterationPath}, State: {WorkItemState}";
+    }
+
+    /// <summary>
+    /// The story points for the work item. 0 is not set.
+    /// </summary>
+    public int StoryPoints { get; }
+
+    /// <summary>
+    /// The work item priority. -1 is not set.
+    /// </summary>
+    public int Priority { get; }
+
+    /// <summary>
+    /// The state for the workitem.
+    /// </summary>
+    /// <remarks>
+    /// The value is based on the GitHub issue state, and the
+    /// correct iteration. If the issue is closed, the work item
+    /// state is "Closed". If the issue is open and the item
+    /// should be in a sprint, the state is "Committed". Otherwise,
+    /// the state is "New".
+    /// </remarks>
+    public string WorkItemState { get; }
+
+    /// <summary>
+    /// The sequence of Azure DevOps tags to apply to the
+    /// associated work item.
+    /// </summary>
+    public IEnumerable<string> Tags { get; }
+
+    /// <summary>
+    /// The path to the iteration for this work item.
+    /// </summary>
+    public string IterationPath { get; }
+
+    /// <summary>
+    /// The parent node ID for this work item. 0 means no parent
+    /// </summary>
+    public int ParentNodeId { get; }
+
+    /// <summary>
+    /// A string that can be used to log the iteration values for the work item.
+    /// </summary>
+    public string IssueLogString { get; }
+
+    private static StoryPointSize? LatestStoryPointSize(QuestIssueOrPullRequest issue)
+    {
+        IEnumerable<StoryPointSize> sizes = from size in issue.ProjectStoryPoints
+                                            let month = StoryPointSize.MonthOrdinal(size.Month)
+                                            orderby size.CalendarYear descending,
+                                            month descending
+                                            select size;
+
+        return sizes.FirstOrDefault();
+    }
+
+    private static int? QuestStoryPoint(StoryPointSize? storyPointSize)
+    {
+        if (storyPointSize?.Size?.Contains("Tiny") == true)
+        {
+            return 1;
+        }
+        else if (storyPointSize?.Size?.Contains("Small") == true)
+        {
+            return 3;
+        }
+        else if (storyPointSize?.Size?.Contains("Medium") == true)
+        {
+            return 5;
+        }
+        else if (storyPointSize?.Size?.Contains("Large") == true)
+        {
+            return 8;
+        }
+        else if (storyPointSize?.Size?.Contains("X-Large") == true)
+        {
+            return 13;
+        }
+        return null;
+    }
+
+    private static int? GetPriority(QuestIssueOrPullRequest issue, StoryPointSize? storySize)
+    {
+        if (storySize?.Priority is not null) return storySize.Priority;
+
+        // Well, check for priority on the issue itself:
+        foreach (var label in issue.Labels)
+        {
+            //Start at 1, because DevOps uses 1 - 4.
+            if (label.Name.StartsWith("P", true, null))
+            {
+                if (label.Name.Contains("0")) return 1;
+                if (label.Name.Contains("1")) return 2;
+                if (label.Name.Contains("2")) return 3;
+                if (label.Name.Contains("3")) return 4;
+            }
+        }
+        return default;
+    }
+
+    private static IEnumerable<string> WorkItemTagsForIssue(QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags)
+    {
+        foreach (var label in issue.Labels)
+        {
+            var tag = tags.FirstOrDefault(t => t.Label == label.Name);
+            if (tag.Tag is not null)
+            {
+                yield return tag.Tag;
+            }
+        }
+    }
 }

--- a/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/ExtendedIssueProperties.cs
@@ -27,24 +27,22 @@ public class ExtendedIssueProperties
         StoryPoints = QuestStoryPoint(storySize) ?? 0;
         Priority = GetPriority(issue, storySize) ?? -1;
         var latestIteration = storySize?.ProjectIteration(iterations) ?? QuestIteration.FutureIteration(iterations);
-        bool IsBackLog = storySize?.IsPastIteration ?? true;
-
-        if (IsBackLog)
+        if (storySize?.IsPastIteration == true)
         {
             latestIteration = QuestIteration.FutureIteration(iterations);
         }
 
-        WorkItemState = (issue.IsOpen, IsBackLog) switch
+        WorkItemState = (issue.IsOpen, latestIteration.Name) switch
         {
             (false, _) => "Closed",
-            (true, false) => "Committed",
-            (_) => "New"
+            (true, "Future") => "New",
+            (_) => "Committed"
         };
         IterationPath = latestIteration.Path;
 
         ParentNodeId = 0;
 
-        if (!IsBackLog)
+        if (WorkItemState is not "New")
         {
             foreach (ParentForLabel pair in parentNodes)
             {

--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -17,7 +17,12 @@ public static class IssueExtensions
         int? priority = issue.GetPriority(storySize);
         bool isPastIteration = storySize?.IsPastIteration ?? false;
 
-        QuestIteration? iteration = storySize?.ProjectIteration(iterations);
+        QuestIteration iteration = storySize?.ProjectIteration(iterations) ?? QuestIteration.FutureIteration(iterations);
+
+        if (isPastIteration || iteration is null)
+        {
+            iteration = QuestIteration.FutureIteration(iterations);
+        }
 
         int parentNodeId = 0;
 
@@ -27,7 +32,7 @@ public static class IssueExtensions
             {
                 if (issue.Labels.Any(l => l.Name == pair.Label) || (pair.Label is null))
                 {
-                    if ((pair.Semester is null) || (iteration?.IsInSemester(pair.Semester) is true))
+                    if ((pair.Semester is null) || (iteration.IsInSemester(pair.Semester) is true))
                     {
                         parentNodeId = pair.ParentNodeId;
                         break;

--- a/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
+++ b/actions/sequester/Quest2GitHub/Models/IssueExtensions.cs
@@ -4,101 +4,6 @@ namespace Quest2GitHub.Models;
 
 public static class IssueExtensions
 {
-    public static ExtendedIssueProperties ExtendedProperties(this QuestIssueOrPullRequest issue,
-        IEnumerable<QuestIteration> iterations,
-        IEnumerable<LabelToTagMap> tags,
-        IEnumerable<ParentForLabel> parentNodes)
-    {
-        StoryPointSize? storySize = issue.LatestStoryPointSize();
-        string GitHubSize = storySize?.Size ?? "Unknown";
-        string month = storySize?.Month ?? "Unknown";
-        int calendarYear = storySize?.CalendarYear ?? 0;
-        int? storyPoints = storySize?.QuestStoryPoint();
-        int? priority = issue.GetPriority(storySize);
-        bool isPastIteration = storySize?.IsPastIteration ?? false;
-
-        QuestIteration iteration = storySize?.ProjectIteration(iterations) ?? QuestIteration.FutureIteration(iterations);
-
-        if (isPastIteration || iteration is null)
-        {
-            iteration = QuestIteration.FutureIteration(iterations);
-        }
-
-        int parentNodeId = 0;
-
-        if (!isPastIteration)
-        {
-            foreach (ParentForLabel pair in parentNodes)
-            {
-                if (issue.Labels.Any(l => l.Name == pair.Label) || (pair.Label is null))
-                {
-                    if ((pair.Semester is null) || (iteration.IsInSemester(pair.Semester) is true))
-                    {
-                        parentNodeId = pair.ParentNodeId;
-                        break;
-                    }
-                }
-            }
-        }
-
-        IEnumerable<string> workItemTags = issue.WorkItemTagsForIssue(tags);
-        return new ExtendedIssueProperties(GitHubSize, storyPoints, priority, iteration, isPastIteration, month, calendarYear, workItemTags, parentNodeId);
-    }
-    private static StoryPointSize? LatestStoryPointSize(this QuestIssueOrPullRequest issue)
-    {
-        IEnumerable<StoryPointSize> sizes = from size in issue.ProjectStoryPoints
-                    let month = StoryPointSize.MonthOrdinal(size.Month)
-                    orderby size.CalendarYear descending,
-                    month descending
-                    select size;
-
-        return sizes.FirstOrDefault();
-    }
-
-    private static int? QuestStoryPoint(this StoryPointSize storyPointSize)
-    {
-        if (storyPointSize.Size.Contains("Tiny"))
-        {
-            return 1;
-        }
-        else if (storyPointSize.Size.Contains("Small"))
-        {
-            return 3;
-        }
-        else if (storyPointSize.Size.Contains("Medium"))
-        {
-            return 5;
-        }
-        else if (storyPointSize.Size.Contains("Large"))
-        {
-            return 8;
-        }
-        else if (storyPointSize.Size.Contains("X-Large"))
-        {
-            return 13;
-        }
-        return null;
-    }
-
-    private static int? GetPriority(this QuestIssueOrPullRequest issue, StoryPointSize? storySize)
-    {
-        if (storySize?.Priority is not null) return storySize.Priority;
-
-        // Well, check for priority on the issue itself:
-        foreach(var label in issue.Labels)
-        {
-            //Start at 1, because DevOps uses 1 - 4.
-            if (label.Name.StartsWith("P", true, null))
-            {
-                if (label.Name.Contains("0")) return 1;
-                if (label.Name.Contains("1")) return 2;
-                if (label.Name.Contains("2")) return 3;
-                if (label.Name.Contains("3")) return 4;
-            }
-        }
-        return default;
-    }
-
     public static QuestIteration? ProjectIteration(this StoryPointSize storyPoints, IEnumerable<QuestIteration> iterations)
     {
         // New form: Content\Gallium\FY24Q1\07
@@ -134,23 +39,5 @@ public static class IssueExtensions
             }
         }
         return default;
-    }
-
-    /// <summary>
-    /// Return tags for a given issue
-    /// </summary>
-    /// <param name="issue">The GitHub issue or pull request</param>
-    /// <param name="tags">The mapping from issue to tag</param>
-    /// <returns>An enumerable of tags</returns>
-    private static IEnumerable<string> WorkItemTagsForIssue(this QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags)
-    {
-        foreach (var label in issue.Labels)
-        {
-            var tag = tags.FirstOrDefault(t => t.Label == label.Name);
-            if (tag.Tag is not null)
-            {
-                yield return tag.Tag;
-            }
-        }
     }
 }

--- a/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestIteration.cs
@@ -9,15 +9,16 @@ public class QuestIteration
 
     public bool IsInSemester(string semesterName) => Path.Contains(semesterName);
 
-    public static QuestIteration? CurrentIteration(IEnumerable<QuestIteration> iterations)
+    public static QuestIteration CurrentIteration(IEnumerable<QuestIteration> iterations)
     {
         var currentYear = int.Parse(DateTime.Now.ToString("yyyy"));
         var currentMonth = DateTime.Now.ToString("MMM");
-        return IssueExtensions.ProjectIteration(currentMonth, currentYear, iterations);
+        var iteration = IssueExtensions.ProjectIteration(currentMonth, currentYear, iterations);
+        return iteration ?? throw new InvalidOperationException("No current iteration found.");
     }
 
-    public static QuestIteration? FutureIteration(IEnumerable<QuestIteration> iterations)
-        => iterations.SingleOrDefault(sprint => sprint.Name is "Future");
+    public static QuestIteration FutureIteration(IEnumerable<QuestIteration> iterations)
+        => iterations.Single(sprint => sprint.Name is "Future");
 
     override public string ToString() => $"{Identifier} {Id} {Name} ({Path})";
 

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -140,7 +140,7 @@ public class QuestWorkItem
         OspoClient? ospoClient,
         string path,
         string? requestLabelNodeId,
-        ExtendedIssueProperties issueProperties)
+        WorkItemProperties issueProperties)
     {
         string areaPath = $"""{questClient.QuestProject}\{path}""";
 
@@ -358,7 +358,7 @@ public class QuestWorkItem
         QuestIssueOrPullRequest ghIssue,
         QuestClient questClient,
         OspoClient? ospoClient,
-        ExtendedIssueProperties issueProperties)
+        WorkItemProperties issueProperties)
     {
         string? ghAssigneeEmailAddress = await ghIssue.QueryAssignedMicrosoftEmailAddressAsync(ospoClient);
         AzDoIdentity? questAssigneeID = default;

--- a/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
+++ b/actions/sequester/Quest2GitHub/Models/QuestWorkItem.cs
@@ -207,7 +207,7 @@ public class QuestWorkItem
             Path = "/fields/System.IterationPath",
             Value = issueProperties.IterationPath,
         });
-        if (issueProperties.StoryPoints is not null)
+        if (issueProperties.StoryPoints != 0)
         {
             patchDocument.Add(new JsonPatchDocument
             {
@@ -217,7 +217,7 @@ public class QuestWorkItem
                 Value = issueProperties.StoryPoints,
             });
         }
-        if (issueProperties.Priority.HasValue)
+        if (issueProperties.Priority != -1)
         {
             patchDocument.Add(new JsonPatchDocument
             {
@@ -414,7 +414,7 @@ public class QuestWorkItem
             patchDocument.Add(assignPatch);
         }
         bool questItemOpen = questItem.State is not "Closed";
-        proposedQuestState = ghIssue.IsOpen ? "Committed" : "Closed";
+        proposedQuestState = issueProperties.WorkItemState;
         if (ghIssue.IsOpen != questItemOpen)
         {
 
@@ -429,13 +429,7 @@ public class QuestWorkItem
                 Value = BuildDescriptionFromIssue(ghIssue, null)
             });
         }
-        QuestIteration iteration = issueProperties.LatestIteration;
-        Console.WriteLine($"Latest GitHub sprint project: {issueProperties.Month}-{issueProperties.CalendarYear}, size: {issueProperties.GitHubSize}");
-        if ((issueProperties.IsPastIteration == true) && (ghIssue.IsOpen == true))
-        {
-            Console.WriteLine($"Moving to the backlog / future iteration.");
-            proposedQuestState = "New";
-        }
+        Console.WriteLine(issueProperties.IssueLogString);
         if (proposedQuestState != questItem.State)
         {
             patchDocument.Add(new JsonPatchDocument
@@ -445,16 +439,16 @@ public class QuestWorkItem
                 Value = proposedQuestState,
             });
         }
-        if (iteration.Path != questItem.IterationPath)
+        if (issueProperties.IterationPath != questItem.IterationPath)
         {
             patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
                 Path = "/fields/System.IterationPath",
-                Value = iteration.Path,
+                Value = issueProperties.IterationPath,
             });
         }
-        if ((issueProperties.StoryPoints is not null) && (issueProperties.StoryPoints != questItem.StoryPoints))
+        if (issueProperties.StoryPoints != questItem.StoryPoints)
         {
             patchDocument.Add(new JsonPatchDocument
             {
@@ -464,13 +458,13 @@ public class QuestWorkItem
                 Value = issueProperties.StoryPoints,
             });
         }
-        if (issueProperties.Priority.HasValue && issueProperties.Priority != questItem.Priority)
+        if (issueProperties.Priority != questItem.Priority)
         {
             patchDocument.Add(new JsonPatchDocument
             {
                 Operation = Op.Add,
                 Path = "/fields/Microsoft.VSTS.Common.Priority",
-                Value = issueProperties.Priority.Value
+                Value = issueProperties.Priority
             });
         }
         var tags = from t in issueProperties.Tags

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -16,9 +16,9 @@ namespace Quest2GitHub.Models;
 /// properties, the project(s) that the issue is a member of
 /// and the environment settings.
 /// </remarks>
-public class ExtendedIssueProperties
+public class WorkItemProperties
 {
-    public ExtendedIssueProperties (QuestIssueOrPullRequest issue,
+    public WorkItemProperties (QuestIssueOrPullRequest issue,
         IEnumerable<QuestIteration> iterations,
         IEnumerable<LabelToTagMap> tags,
         IEnumerable<ParentForLabel> parentNodes)

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -59,15 +59,6 @@ public sealed record class ImportOptions
     public List<ParentForLabel> ParentNodes { get; init; } = [];
 
     /// <summary>
-    /// The default parent node for any quest item.
-    /// </summary>
-    /// <remarks>
-    /// If an issue doesn't match any of the configured labels
-    /// the default parent node is set for the work item.
-    /// </remarks>
-    public int DefaultParentNode { get; init; }
-
-    /// <summary>
     /// A map of GitHub labels to Azure DevOps tags.
     /// </summary>
     /// <remarks>

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -99,7 +99,7 @@ public class QuestGitHubService(
             {
                 if (item.Labels.Any(l => (l.Id == _importTriggerLabel?.Id) || (l.Id == _importedLabel?.Id)))
                 {
-                    var issueProperties = item.ExtendedProperties(_allIterations, tagMap, parentNodes);
+                    var issueProperties = new ExtendedIssueProperties(item, _allIterations, tagMap, parentNodes);
 
                     // TODO: Move to issue Properties ToString:
                     // Console.WriteLine($"{item.Number}: {item.Title}, {item.LatestStoryPointSize()?.Month ?? "???"}-{(item.LatestStoryPointSize()?.CalendarYear)?.ToString() ?? "??"}");
@@ -189,7 +189,7 @@ public class QuestGitHubService(
             ? await FindLinkedWorkItemAsync(ghIssue)
             : null;
 
-        var issueProperties = ghIssue.ExtendedProperties(_allIterations, tagMap, parentNodes);
+        var issueProperties = new ExtendedIssueProperties(ghIssue, _allIterations, tagMap, parentNodes);
 
         // The order here is important to avoid a race condition that causes
         // an issue to be triggered multiple times.

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -22,7 +22,6 @@ namespace Quest2GitHub;
 /// <param name="areaPath">The area path for work items from this repo</param>
 /// <param name="importTriggerLabelText">The text of the label that triggers an import</param>
 /// <param name="importedLabelText">The text of the label that indicates an issue has been imported</param>
-/// <param name="defaultParentNode">The ID of the default parent work item ID.</param>
 /// <param name="parentNodes">A dictionary of label / parent ID pairs.</param>
 /// <remarks>
 /// The OAuth token takes precedence over the GitHub token, if both are 
@@ -37,7 +36,6 @@ public class QuestGitHubService(
     string areaPath,
     string importTriggerLabelText,
     string importedLabelText,
-    int defaultParentNode,
     List<ParentForLabel> parentNodes,
     IEnumerable<LabelToTagMap> tagMap) : IDisposable
 {
@@ -109,7 +107,7 @@ public class QuestGitHubService(
                     {
                         if (questItem != null)
                         {
-                            await QuestWorkItem.UpdateWorkItemAsync(questItem, item, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes, defaultParentNode);
+                            await QuestWorkItem.UpdateWorkItemAsync(questItem, item, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes);
                         }
                         else
                         {
@@ -206,7 +204,7 @@ public class QuestGitHubService(
             {
                 // This allows a human to force a manual update: just add the trigger label.
                 // Note that it updates even if the item is closed.
-                await QuestWorkItem.UpdateWorkItemAsync(questItem, ghIssue, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes, defaultParentNode);
+                await QuestWorkItem.UpdateWorkItemAsync(questItem, ghIssue, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes);
 
             }
             // Next, if the item is already linked, consider any updates.
@@ -217,7 +215,7 @@ public class QuestGitHubService(
         }
         else if (sequestered && questItem is not null)
         {
-            await QuestWorkItem.UpdateWorkItemAsync(questItem, ghIssue, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes, defaultParentNode);
+            await QuestWorkItem.UpdateWorkItemAsync(questItem, ghIssue, _azdoClient, _ospoClient, _allIterations, tagMap, parentNodes);
         }
     }
 
@@ -303,7 +301,7 @@ public class QuestGitHubService(
         {
             // Create work item:
             QuestWorkItem questItem = await QuestWorkItem.CreateWorkItemAsync(issueOrPullRequest, _azdoClient, _ospoClient, areaPath,
-                _importTriggerLabel?.Id, currentIteration, allIterations, tagMap, parentNodes, defaultParentNode);
+                _importTriggerLabel?.Id, currentIteration, allIterations, tagMap, parentNodes);
 
             string linkText = $"[{LinkedWorkItemComment}{questItem.Id}]({_questLinkString}{questItem.Id})";
             string updatedBody = $"""

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -101,8 +101,7 @@ public class QuestGitHubService(
                 {
                     var issueProperties = new ExtendedIssueProperties(item, _allIterations, tagMap, parentNodes);
 
-                    // TODO: Move to issue Properties ToString:
-                    // Console.WriteLine($"{item.Number}: {item.Title}, {item.LatestStoryPointSize()?.Month ?? "???"}-{(item.LatestStoryPointSize()?.CalendarYear)?.ToString() ?? "??"}");
+                    Console.WriteLine($"{item.Number}: {item.Title}, {issueProperties.IssueLogString}");
                     // Console.WriteLine(item);
                     QuestWorkItem? questItem = await FindLinkedWorkItemAsync(item);
                     if (questItem != null)
@@ -322,21 +321,6 @@ public class QuestGitHubService(
             {
                 var prMutation = new Mutation<SequesteredPullRequestMutation, SequesterVariables>(ghClient);
                 await prMutation.PerformMutation(new SequesterVariables(pr.Id, _importTriggerLabel?.Id ?? "", _importedLabel?.Id ?? "", updatedBody));
-            }
-            // All work items are created in the "New" state, despite the REST packet
-            // indicating the "Committed" status. So, update the state to "Committed".
-            // TODO:  Update closed items correctly here. And updated "future" items here as well.
-            List<JsonPatchDocument> patchDocument = [];
-            patchDocument.Add(new JsonPatchDocument
-            {
-                Operation = Op.Add,
-                Path = "/fields/System.State",
-                Value = "Committed",
-            });
-            if (patchDocument.Count != 0)
-            {
-                JsonElement jsonDocument = await _azdoClient.PatchWorkItem(questItem.Id, patchDocument);
-                questItem = QuestWorkItem.WorkItemFromJson(jsonDocument);
             }
             return questItem;
         }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -101,7 +101,8 @@ public class QuestGitHubService(
             {
                 if (item.Labels.Any(l => (l.Id == _importTriggerLabel?.Id) || (l.Id == _importedLabel?.Id)))
                 {
-                    Console.WriteLine($"{item.Number}: {item.Title}, {item.LatestStoryPointSize()?.Month ?? "???"}-{(item.LatestStoryPointSize()?.CalendarYear)?.ToString() ?? "??"}");
+                    // TODO: Move to issue Properties ToString:
+                    // Console.WriteLine($"{item.Number}: {item.Title}, {item.LatestStoryPointSize()?.Month ?? "???"}-{(item.LatestStoryPointSize()?.CalendarYear)?.ToString() ?? "??"}");
                     // Console.WriteLine(item);
                     QuestWorkItem? questItem = await FindLinkedWorkItemAsync(item);
                     if (currentIteration is not null)
@@ -324,6 +325,7 @@ public class QuestGitHubService(
             }
             // All work items are created in the "New" state, despite the REST packet
             // indicating the "Committed" status. So, update the state to "Committed".
+            // TODO:  Update closed items correctly here. And updated "future" items here as well.
             List<JsonPatchDocument> patchDocument = [];
             patchDocument.Add(new JsonPatchDocument
             {

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -99,7 +99,7 @@ public class QuestGitHubService(
             {
                 if (item.Labels.Any(l => (l.Id == _importTriggerLabel?.Id) || (l.Id == _importedLabel?.Id)))
                 {
-                    var issueProperties = new ExtendedIssueProperties(item, _allIterations, tagMap, parentNodes);
+                    var issueProperties = new WorkItemProperties(item, _allIterations, tagMap, parentNodes);
 
                     Console.WriteLine($"{item.Number}: {item.Title}, {issueProperties.IssueLogString}");
                     // Console.WriteLine(item);
@@ -188,7 +188,7 @@ public class QuestGitHubService(
             ? await FindLinkedWorkItemAsync(ghIssue)
             : null;
 
-        var issueProperties = new ExtendedIssueProperties(ghIssue, _allIterations, tagMap, parentNodes);
+        var issueProperties = new WorkItemProperties(ghIssue, _allIterations, tagMap, parentNodes);
 
         // The order here is important to avoid a race condition that causes
         // an issue to be triggered multiple times.
@@ -295,7 +295,7 @@ public class QuestGitHubService(
         }
     }
 
-    private async Task<QuestWorkItem> LinkIssueAsync(QuestIssueOrPullRequest issueOrPullRequest, ExtendedIssueProperties issueProperties)
+    private async Task<QuestWorkItem> LinkIssueAsync(QuestIssueOrPullRequest issueOrPullRequest, WorkItemProperties issueProperties)
     {
         int? workItem = LinkedQuestId(issueOrPullRequest);
         if (workItem is null)


### PR DESCRIPTION
Fixes dotnet/docs-tool#417

Move all the logic that computes the properties for an Azure DevOps item from various locations to a single type. That type's constructor now builds the properties from the GitHub issue and associated projects.

The code that creates or updates an AzDo item uses this logic instead of copied code.

Two bonus fixes are part of this:

1. Work items put in the "Future" iteration are set without a parent node, and are set to the "New" state. Previously, those items had the current default node for the repo as their parent, and were in the "Committed" state.
2. The Work item description is updated anytime the work item is updated as part of its normal processing. Previously, it was only if the issue Open / Closed state had changed.

This might be easier to review commit-by-commit. Each update moved some code, and added or updates some tests.
