### PR TITLE
[CleanRepo] Add ability to limit search for referencing files & more

### DIFF
--- a/cleanrepo/Options.cs
+++ b/cleanrepo/Options.cs
@@ -1,6 +1,5 @@
 ﻿namespace CleanRepo;
 
-// Define a class to represent config options.
 class Options
 {
     public string? DocFxDirectory { get; set; }
@@ -11,4 +10,5 @@ class Options
     public string? Function { get; set; }
     public string? OcrModelDirectory { get; set; }
     public string? FilterTextJsonFile { get; set; }
+    public List<string>? LimitReferencingDirectories { get; set; }
 }

--- a/cleanrepo/Program.cs
+++ b/cleanrepo/Program.cs
@@ -1014,9 +1014,11 @@ class Program
 
         Dictionary<string, int> filesToKeep = [];
 
+        // Exclude certain Markdown files.
         static bool IsArticleFile(FileInfo file) =>
             !file.FullName.Contains($"{Path.DirectorySeparatorChar}includes{Path.DirectorySeparatorChar}") &&
             !file.FullName.Contains($"{Path.DirectorySeparatorChar}misc{Path.DirectorySeparatorChar}") &&
+            !file.FullName.Contains($"{Path.DirectorySeparatorChar}mermaidjs{Path.DirectorySeparatorChar}") &&
             string.Compare(file.Name, "TOC.md", StringComparison.InvariantCultureIgnoreCase) != 0 &&
             string.Compare(file.Name, "index.md", StringComparison.InvariantCultureIgnoreCase) != 0;
 

--- a/cleanrepo/Repo.cs
+++ b/cleanrepo/Repo.cs
@@ -34,10 +34,11 @@ class DocFxRepo(string startDirectory, string urlBasePath)
     {
         get
         {
+            DirectoryInfo? rootDirectory = null;
             if (_allMdAndYmlFiles == null)
             {
-                _allMdAndYmlFiles = HelperMethods.GetAllMarkdownFiles(DocFxDirectory!.FullName, out _);
-                List<FileInfo>? yamlFiles = HelperMethods.GetAllYamlFiles(DocFxDirectory!.FullName, out _);
+                _allMdAndYmlFiles = HelperMethods.GetAllReferencingFiles("*.md", DocFxDirectory!.FullName, ref rootDirectory);
+                List<FileInfo>? yamlFiles = HelperMethods.GetAllReferencingFiles("*.yml", DocFxDirectory!.FullName, ref rootDirectory);
                 if (yamlFiles is not null)
                     _allMdAndYmlFiles?.AddRange(yamlFiles);
             }


### PR DESCRIPTION
- Exclude mermaidjs directories from orphaned articles search
- Add ability to limit referencing file search to certain directories (useful for very large repos and targeted searches)
- Consolidate the "find all MD/YML/XML files" into a single method