### PR TITLE
CLosed issues should go in the last (past) project

### DIFF
--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -661,7 +661,7 @@ public class BuildExtendedPropertiesTests
     }
 
     [Fact]
-    public static void BuildExtensionForSinglePastProject()
+    public static void BuildExtensionForOpenIssueSinglePastProject()
     {
         var extendedProperties = CreateIssueObject(SingleIssuePastProject);
 
@@ -682,13 +682,13 @@ public class BuildExtendedPropertiesTests
         // Check each property:
         Assert.Equal(5, extendedProperties.StoryPoints);
         Assert.Equal(2, extendedProperties.Priority);
-        Assert.Equal("Content\\Future", extendedProperties.IterationPath);
+        Assert.Equal("Content\\Dilithium\\FY25Q1\\07 Jul", extendedProperties.IterationPath);
         Assert.Equal("Closed", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
-        Assert.Equal(0, extendedProperties.ParentNodeId);
+        Assert.Equal(11, extendedProperties.ParentNodeId);
     }
     [Fact]
-    public static void BuildExtensionForMultiplePastProject()
+    public static void BuildExtensionForOpenIssueMultiplePastProject()
     {
         var extendedProperties = CreateIssueObject(MultipleIssuePastProject);
 

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -27,7 +27,7 @@ public class WorkItemProperties
         StoryPoints = QuestStoryPoint(storySize) ?? 0;
         Priority = GetPriority(issue, storySize) ?? -1;
         var latestIteration = storySize?.ProjectIteration(iterations) ?? QuestIteration.FutureIteration(iterations);
-        if (storySize?.IsPastIteration == true)
+        if ((storySize?.IsPastIteration == true) && issue.IsOpen)
         {
             latestIteration = QuestIteration.FutureIteration(iterations);
         }


### PR DESCRIPTION
Fix a bug where an issue that is only a member of closed projects would be unconditionally assigned to the future sprint, even if it was closed.