### PR TITLE
Create new file, if necessary

### DIFF
--- a/WhatsNew.Infrastructure/Services/PageGenerationService.cs
+++ b/WhatsNew.Infrastructure/Services/PageGenerationService.cs
@@ -58,9 +58,9 @@ public class PageGenerationService
             return;
         }
 
-        if (string.IsNullOrWhiteSpace(existingMarkdownFile))
+        if (string.IsNullOrWhiteSpace(existingMarkdownFile) || !File.Exists(existingMarkdownFile))
         {
-            var filePath = GetMarkdownFilePath();
+            var filePath = string.IsNullOrWhiteSpace(existingMarkdownFile) ? GetMarkdownFilePath() : existingMarkdownFile;
             await using TextWriter stream = new StreamWriter(filePath);
 
             await GenerateHeader(stream);


### PR DESCRIPTION
The tool was crashing in the mode where it edited a single file if that file doesn't exist, Instead, if the path is valid, and the file doesn't exist, create it.

Fixes #459 