### PR TITLE
Add a command to CleanRepo to provide data on the difference bewteen the `ms.date` value and latest commit

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/FileHistory.cs
+++ b/DotNet.DocsTools/GitHubObjects/FileHistory.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DotNetDocs.Tools.GitHubCommunications;
+
+namespace DotNet.DocsTools.GitHubObjects;
+
+/// <summary>
+/// The query variables for file history
+/// </summary>
+/// <param name="owner">The GitHub org for the repository</param>
+/// <param name="repo">The repository name</param>
+/// <param name="path">The path to the file</param>
+public readonly record struct FileHistoryVariables(string owner, string repo, string path);
+
+public class FileHistory : IGitHubQueryResult<FileHistory, FileHistoryVariables>
+{
+    private const string FileHistoryQueryText = """
+        query FileHistory($owner: String!, $repo: String!, $path: String!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            defaultBranchRef {
+              target {
+                ... on Commit {
+                  history(
+                    first: 25
+                    after: $cursor
+                    path: $path
+                  ) {
+                    nodes {
+                      committedDate
+                      changedFilesIfAvailable
+                      additions
+                      deletions
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """;
+
+
+    public DateTime CommittedDate { get; }
+
+    public int? ChangedFilesIfAvailable { get; }
+
+    public int Additions { get; }
+
+    public int Deletions { get; }
+    private FileHistory(JsonElement element)
+    {
+        CommittedDate = ResponseExtractors.DateTimeProperty(element, "committedDate");
+        ChangedFilesIfAvailable = ResponseExtractors.IntProperty(element, "changedFilesIfAvailable");
+        Additions = ResponseExtractors.IntProperty(element, "additions");
+        Deletions = ResponseExtractors.IntProperty(element, "deletions");
+    }
+
+    public static GraphQLPacket GetQueryPacket(FileHistoryVariables variables, bool isScalar) =>
+        (isScalar)
+        ? throw new InvalidOperationException("This query is not a scalar query")
+        : new()
+        {
+            query = FileHistoryQueryText,
+            variables =
+            {
+                ["owner"] = variables.owner,
+                ["repo"] = variables.repo,
+                ["path"] = variables.path,
+            }
+        };
+
+    public static IEnumerable<string> NavigationToNodes(bool isScalar) =>
+        (isScalar)
+        ? throw new InvalidOperationException("This query is not a scalar query")
+        : ["repository", "defaultBranchRef", "target", "history"];
+
+    public static FileHistory? FromJsonElement(JsonElement element, FileHistoryVariables variables) =>
+                new FileHistory(element);
+}

--- a/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
+++ b/DotNet.DocsTools/GitHubObjects/ResponseExtractors.cs
@@ -112,4 +112,10 @@ internal static class ResponseExtractors
         }
         throw new ArgumentException($"Property {propertyName} not found in Json element. Did you possibly access the parent node?", nameof(element));
     }
+
+    internal static DateTime DateTimeProperty(JsonElement element, string propertyName)
+    {
+        return OptionalDateProperty(element, propertyName)
+            ?? throw new ArgumentException("Requested property shouldn't be null", nameof(propertyName));
+    }
 }

--- a/cleanrepo/CleanRepo.csproj
+++ b/cleanrepo/CleanRepo.csproj
@@ -22,6 +22,9 @@
     <PackageReference Include="Microsoft.Build" Version="17.12.6" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\DotNet.DocsTools\DotNet.DocsTools.csproj" />
+  </ItemGroup>
+  <ItemGroup>
     <None Update="appSettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/cleanrepo/Program.cs
+++ b/cleanrepo/Program.cs
@@ -389,6 +389,8 @@ class Program
 
     private static async Task AuditMSDateAccuracy(Options options, DocFxRepo docFxRepo, List<FileInfo> articleFiles)
     {
+        if (options.DocFxDirectory is null)
+            return;
         var config = new ConfigurationBuilder()
             .AddEnvironmentVariables()
             .Build();
@@ -399,7 +401,7 @@ class Program
         int freshArticles = 0;
         int trulyStateArticles = 0;
         int falseStaleArticles = 0;
-        // Make this configurable:
+        // This could be configurable in time (or now, even):
         DateOnly staleContentDate = DateOnly.FromDateTime(DateTime.Now.AddYears(-1));
 
         var linkedArticles = from article in articleFiles

--- a/cleanrepo/Program.cs
+++ b/cleanrepo/Program.cs
@@ -438,7 +438,7 @@ class Program
 
             // Give a week from msDate to allow for PR edits before merging.
             // Without this buffer of time, the checks below often include
-            // the PR where the date was updated. That creates in a lot of
+            // the PR where the date was updated. That results in a lot of
             // false positives.
             DateOnly msDateMergeDate = DateOnly.FromDateTime(new DateTime(msDate.Value, default).AddDays(7));
 

--- a/cleanrepo/README.md
+++ b/cleanrepo/README.md
@@ -11,6 +11,7 @@ This command-line tool helps you clean up a DocFx-based content repo. It can:
 - Remove daisy chains (or hops) within the redirection files for the docset.
 - Replace site-relative links with file-relative links (includes image links).
 - Filter image list based on strings found in images.
+- Compare `ms.date` metadata and recent commit data.
 
 ## Usage
 
@@ -31,6 +32,7 @@ The available functions are described in the following table.
 | ReplaceWithRelativeLinks | Replace site-relative links with file-relative links. |
 | CatalogImagesWithText | Map images to the markdown/YAML files that reference them, with all text found in images. The output file is prefixed with `OcrImageFiles-`. |
 | FilterImagesForText | Filter images for text. The output file is prefixed with `FilteredOcrImageFiles-`. |
+| AuditMSDate | Compare `ms.date` metadata to most recent commits. This can take a long time on a full repo. It also requires a [GitHub PAT](https://github.com/settings/tokens) with read privileges for the repository you want to check. Store this PAT in an environment variable named `GITHUB_KEY`.
 
 ## Image to text examples
 


### PR DESCRIPTION
For every article in the repo, 

- Find its `ms.date` value
- Run a GitHub query to show the differences between the latest commit and the `ms.date. value.
- Print those stats.

Here's sample output from the C# Guide:

```console
PRs Changes Last Commit    ms.date Path
  2    1482  08-22-2024 09-02-2022 docs/csharp/event-pattern.md
  1       3  07-31-2024 09-15-2021 docs/csharp/nullable-migration-strategies.md
  2    1294  06-07-2024 02-09-2023 docs/csharp/asynchronous-programming/cancel-an-async-task-or-a-list-of-tasks.md
...<snip>... 
  1    1265  06-07-2024 02-06-2018 docs/csharp/roslyn-sdk/get-started/semantic-analysis.md
  1    1265  06-07-2024 02-05-2018 docs/csharp/roslyn-sdk/get-started/syntax-analysis.md
  1    1265  06-07-2024 06-01-2018 docs/csharp/roslyn-sdk/get-started/syntax-transformation.md
  1    1481  08-22-2024 10-23-2018 docs/csharp/tutorials/exploration/interpolated-strings-local.md
 1281 checked. Fresh: 151. Truly stale: 865. Updated but not fresh: 127
 ```

