### PR TITLE
Fix the configuration for actions

### DIFF
--- a/cleanrepo.Dockerfile
+++ b/cleanrepo.Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/sdk:9.0 as build-env
 # Copy everything and publish the release (publish implicitly restores and builds)
 WORKDIR /app
 COPY . ./
-RUN dotnet publish "CleanRepo.csproj" -c Release -o out --no-self-contained
+RUN dotnet publish "./cleanrepo/CleanRepo.csproj" -c Release -o out --no-self-contained
 
 # Relayer the .NET SDK, anew with the build output
 FROM mcr.microsoft.com/dotnet/sdk:9.0

--- a/cleanrepo/action.yml
+++ b/cleanrepo/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: true
 runs:
   using: docker
-  image: Dockerfile
+  image: ../cleanrepo/Dockerfile
   args:
     - '/Options:Function'
     - ${{ inputs.function }}


### PR DESCRIPTION
Because cleanrepo now has a dependency on the docs-tools library, build from the parent folder, and adjust the Dockerfile accordingly.