### PR TITLE
Workaround rate limit

### DIFF
--- a/.github/workflows/quest-bulk.yml
+++ b/.github/workflows/quest-bulk.yml
@@ -1,8 +1,8 @@
 name: "bulk quest import"
 on:
   schedule:
-    - cron: '0 10 * * *' # UTC time, that's 5:00 am EST, 2:00 am PST.
-    - cron: '0 9 6 * *'  # This is the morning of the 6th.
+    - cron: '30 5 1-5,7-31 * *' # 5:30 UTC time, that's 12:30 am EST, 9:30 Pm PST.
+    - cron: '30 5 6 * *'  # This is the morning of the 6th.
 
   workflow_dispatch:
     inputs:
@@ -51,4 +51,4 @@ jobs:
           org: ${{ github.repository_owner }}
           repo: ${{ github.repository }}
           issue: '-1'
-          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '0 9 6 * *' && -1 || 5 }}
+          duration: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.duration || github.event.schedule == '30 5 6 * *' && -1 || 5 }}

--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -345,21 +345,32 @@ public abstract record QuestIssueOrPullRequest : Issue
     /// <param name="ospoClient">The Open Source program office client service.</param>
     /// <returns>The email address of the assignee. Null if unassigned, or the assignee is not a 
     /// Microsoft FTE.</returns>
-    public async Task<string?> QueryAssignedMicrosoftEmailAddressAsync(OspoClient? ospoClient)
+    public async Task<string?> QueryAssignedMicrosoftEmailAddressAsync(OspoClient? ospoClient, IEnumerable<string> trackedGitHubLogins)
     {
-        if ((Assignees.Length != 0) && (ospoClient is not null))
+        string? selectedAssignee = default;
+        foreach(var account in Assignees)
         {
-            OspoLink? identity = await ospoClient.GetAsync(Assignees.First().Login);
-            // This feels like a hack, but it is necessary.
-            // The email address is the email address a person configured
-            // However, the only guaranteed way to find the person in Quest 
-            // is to use their alias as an email address. Yuck.
-            if (identity?.MicrosoftInfo?.EmailAddress?.EndsWith("@microsoft.com") == true)
-                return identity.MicrosoftInfo.Alias + "@microsoft.com";
-            else
-                return identity?.MicrosoftInfo?.EmailAddress;
+            if (trackedGitHubLogins.Any(l => l == account.Login))
+            {
+                selectedAssignee = account.Login;
+                break;
+            }
         }
-        return null;
+        OspoLink? identity = (selectedAssignee, ospoClient) switch
+        {
+            (_, null) => null,
+            (null, _) => null,
+            (_, _) => await ospoClient.GetAsync(selectedAssignee)
+        };
+
+        // This feels like a hack, but it is necessary.
+        // The email address is the email address a person configured
+        // However, the only guaranteed way to find the person in Quest 
+        // is to use their alias as an email address. Yuck.
+        if (identity?.MicrosoftInfo?.EmailAddress?.EndsWith("@microsoft.com") == true)
+            return identity.MicrosoftInfo.Alias + "@microsoft.com";
+        else
+            return identity?.MicrosoftInfo?.EmailAddress;
     }
 
     /// <summary>

--- a/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
+++ b/DotNet.DocsTools/GitHubObjects/QuestIssueOrPullRequest.cs
@@ -350,7 +350,7 @@ public abstract record QuestIssueOrPullRequest : Issue
         string? selectedAssignee = default;
         foreach(var account in Assignees)
         {
-            if (trackedGitHubLogins.Any(l => l == account.Login))
+            if (trackedGitHubLogins.Any(l => string.Compare(l, account.Login, true) == 0))
             {
                 selectedAssignee = account.Login;
                 break;

--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -119,6 +119,7 @@ internal class Program
                 options.ImportedLabel,
                 options.UnlinkLabel,
                 options.ParentNodes,
-                options.WorkItemTags);
+                options.WorkItemTags,
+                options.TeamGitHubLogins);
     }
 }

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -80,4 +80,31 @@ public sealed record class ImportOptions
     /// the mapped AzureDevOps item.
     /// </remarks>
     public List<LabelToTagMap> WorkItemTags { get; init; } = [];
+
+    /// <summary>
+    /// The only set of GitHub logins that we monitor
+    /// </summary>
+    /// <remarks>
+    /// This set of logins are the only set that we expect
+    /// to see for importing Azure DevOps items. Items assigned to
+    /// others won't be imported.
+    /// <p>
+    /// In time, these ids should be stored in a global config
+    /// object. In the short term, this is quicker for testing
+    /// to ensure that it avoid our rate limit issues.
+    /// </p>
+    /// </remarks>
+    public List<string> TeamGitHubLogins { get; init; } =
+        [
+        "CamSoper",
+        "BillWagner",
+        "tdykstra",
+        "IEvangelist",
+        "davidbritch",
+        "gewarren",
+        "cmastr",
+        "adegeo",
+        "Rick-Anderson",
+        "wadepickett"
+        ];
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -40,7 +40,8 @@ public class QuestGitHubService(
     string importedLabelText,
     string removeLinkItemText,
     List<ParentForLabel> parentNodes,
-    IEnumerable<LabelToTagMap> tagMap) : IDisposable
+    IEnumerable<LabelToTagMap> tagMap,
+    IEnumerable<string> gitHubLogins) : IDisposable
 {
     private const string LinkedWorkItemComment = "Associated WorkItem - ";
     private readonly QuestClient _azdoClient = new(azdoKey, questOrg, questProject);
@@ -104,7 +105,7 @@ public class QuestGitHubService(
                         (_, _, true, null) => Task.CompletedTask, // Unlink, but no link. Do nothing.
                         (_, _, false, null) => LinkIssueAsync(item, issueProperties), // No link, but one of the link labels was applied.
                         (_, _, true, not null) => questItem.RemoveWorkItem(item, _azdoClient, issueProperties), // Unlink.
-                        (_, _, false, not null) => questItem.UpdateWorkItemAsync(item, _azdoClient, _ospoClient, issueProperties), // update
+                        (_, _, false, not null) => questItem.UpdateWorkItemAsync(item, _azdoClient, _ospoClient, gitHubLogins, issueProperties), // update
                     };
                     totalImport++;
                 }
@@ -189,7 +190,7 @@ public class QuestGitHubService(
             (    _,     _,  true,     null) => Task.CompletedTask, // Unlink, but no link. Do nothing.
             (    _,     _, false,     null) => LinkIssueAsync(ghIssue, issueProperties), // No link, but one of the link labels was applied.
             (    _,     _,  true, not null) => questItem.RemoveWorkItem(ghIssue, _azdoClient, issueProperties), // Unlink.
-            (    _,     _, false, not null) => questItem.UpdateWorkItemAsync(ghIssue, _azdoClient, _ospoClient, issueProperties), // update
+            (    _,     _, false, not null) => questItem.UpdateWorkItemAsync(ghIssue, _azdoClient, _ospoClient, gitHubLogins, issueProperties), // update
         };
         await workDone;
     }
@@ -298,7 +299,7 @@ public class QuestGitHubService(
             }
 
             // Because some fields can't be set when an item is created, go through an update cycle:
-            await questItem.UpdateWorkItemAsync(issueOrPullRequest, _azdoClient, _ospoClient, issueProperties);
+            await questItem.UpdateWorkItemAsync(issueOrPullRequest, _azdoClient, _ospoClient, gitHubLogins, issueProperties);
             return questItem;
         }
         else

--- a/actions/sequester/README.md
+++ b/actions/sequester/README.md
@@ -37,6 +37,20 @@ To install the GitHub actions:
 
 > **Note**: You may need to configure GitHub Actions in your repository settings. For more information, see [Managing GitHub Actions settings for a repository](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).
 
+## Staggering times
+
+To minimize having all the runs hit REST APIs at the same time, the action configs in different repositories are staggered as follows:
+
+| Repository      | Time (UTC)  |
+|-----------------|-------------|
+| docs-maui       | 02:00       |
+| docs-aspire     | 04:00       |
+| docs-tools      | 05:30       |
+| docs            | 07:00       |
+| docs-desktop    | 09:00       |
+| dotnet-api-docs | 10:30       |
+| AspNetCore.Docs | 12:30       |
+
 ## Suggestions for future releases
 
 - [ ] Populate the "GitHub Repo" field in Azure DevOps to make reporting by repository easier.


### PR DESCRIPTION
Update the code that maps GitHub assignee to Azure DevOps assignee so that the REST API is accessed less frequently.

In addition, change the time this runs (there will be similar PRs in other repos to stagger the runs across the night across the world.