### PR TITLE
Tag workitems assigned to Copilot

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -120,6 +120,7 @@ internal class Program
                 options.UnlinkLabel,
                 options.ParentNodes,
                 options.WorkItemTags,
-                options.TeamGitHubLogins);
+                options.TeamGitHubLogins,
+                options.CopilotIssueTag);
     }
 }

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -738,7 +738,7 @@ public class BuildExtendedPropertiesTests
             issueNumber = 1111
         };
         JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
-        return new WorkItemProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap);
+        return new WorkItemProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap, "copilotTag");
     }
 
 }

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -21,7 +21,8 @@ public class WorkItemProperties
     public WorkItemProperties (QuestIssueOrPullRequest issue,
         IEnumerable<QuestIteration> iterations,
         IEnumerable<LabelToTagMap> tags,
-        IEnumerable<ParentForLabel> parentNodes)
+        IEnumerable<ParentForLabel> parentNodes,
+        string copilotTag)
     {
         StoryPointSize? storySize = LatestStoryPointSize(issue);
         StoryPoints = QuestStoryPoint(storySize) ?? 0;
@@ -57,7 +58,7 @@ public class WorkItemProperties
             }
         }
 
-        Tags = WorkItemTagsForIssue(issue, tags);
+        Tags = WorkItemTagsForIssue(issue, tags, copilotTag);
 
         string month = storySize?.Month ?? "Unknown";
         int calendarYear = storySize?.CalendarYear ?? 0;
@@ -163,7 +164,7 @@ public class WorkItemProperties
         return default;
     }
 
-    private static IEnumerable<string> WorkItemTagsForIssue(QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags)
+    private static IEnumerable<string> WorkItemTagsForIssue(QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags, string copilotTag)
     {
         foreach (var label in issue.Labels)
         {
@@ -172,6 +173,11 @@ public class WorkItemProperties
             {
                 yield return tag.Tag;
             }
+        }
+        // Add custom tag if one of the assignees is "Copilot":
+        if (issue.Assignees.Any(a => (a.Login == "Copilot") && (string.IsNullOrWhiteSpace(a.Name))))
+        {
+            yield return copilotTag;
         }
     }
 }

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -99,7 +99,6 @@ public sealed record class ImportOptions
         "BillWagner",
         "tdykstra",
         "IEvangelist",
-        "davidbritch",
         "gewarren",
         "cmastr",
         "adegeo",

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -96,7 +96,6 @@ public sealed record class ImportOptions
     /// </remarks>
     public List<string> TeamGitHubLogins { get; init; } =
         [
-        "CamSoper",
         "BillWagner",
         "tdykstra",
         "IEvangelist",
@@ -104,7 +103,15 @@ public sealed record class ImportOptions
         "gewarren",
         "cmastr",
         "adegeo",
-        "Rick-Anderson",
         "wadepickett"
         ];
+
+    /// <summary>
+    /// This tag is added to issues that are assigned to Copilot.
+    /// </summary>
+    /// <remarks>
+    /// The human assignee is assigned to review and prompt Copilot to perform
+    /// the toil of the work.
+    /// </remarks>
+    public string CopilotIssueTag { get; init; } = "Assignee-Copilot";
 }

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -41,7 +41,8 @@ public class QuestGitHubService(
     string removeLinkItemText,
     List<ParentForLabel> parentNodes,
     IEnumerable<LabelToTagMap> tagMap,
-    IEnumerable<string> gitHubLogins) : IDisposable
+    IEnumerable<string> gitHubLogins,
+    string copilotTag) : IDisposable
 {
     private const string LinkedWorkItemComment = "Associated WorkItem - ";
     private readonly QuestClient _azdoClient = new(azdoKey, questOrg, questProject);
@@ -96,7 +97,7 @@ public class QuestGitHubService(
                     QuestWorkItem? questItem = (request || sequestered || vanquished)
                         ? await FindLinkedWorkItemAsync(item)
                         : null;
-                    var issueProperties = new WorkItemProperties(item, _allIterations, tagMap, parentNodes);
+                    var issueProperties = new WorkItemProperties(item, _allIterations, tagMap, parentNodes, copilotTag);
 
                     Console.WriteLine($"{item.Number}: {item.Title}, {issueProperties.IssueLogString}");
                     Task workDone = (request, sequestered, vanquished, questItem) switch
@@ -183,7 +184,7 @@ public class QuestGitHubService(
             ? await FindLinkedWorkItemAsync(ghIssue)
             : null;
 
-        var issueProperties = new WorkItemProperties(ghIssue, _allIterations, tagMap, parentNodes);
+        var issueProperties = new WorkItemProperties(ghIssue, _allIterations, tagMap, parentNodes, copilotTag);
 
         Task workDone = (request, sequestered, vanquished, questItem) switch
         {


### PR DESCRIPTION
As we experiment with assigning some issues to Copilot, we want to track that activity.

This tags any imported issue where one of the assignees is "Copilot".