### PR TITLE
Support .NET 10 single file projectless compile

### DIFF
--- a/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
+++ b/snippets5000/PullRequestSimulations/PullRequestSimulations.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -16,9 +16,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/snippets5000/PullRequestSimulations/data.json
+++ b/snippets5000/PullRequestSimulations/data.json
@@ -15,6 +15,21 @@
 
   // GOOD items
   {
+    "Name": "Edit - Single file no project - Compile",
+    "ExpectedResults": [
+      {
+        "ResultCode": 0,
+        "DiscoveredProject": "snippets/good/normal/single_code_file/Now.cs"
+      }
+    ],
+    "Items": [
+      {
+        "ItemType": "Edit",
+        "Path": "snippets/good/normal/single_code_file/Now.cs"
+      }
+    ]
+  },
+  {
     "Name": "Edit - Single file find project C#",
     "ExpectedResults": [
       {
@@ -152,6 +167,21 @@
     ]
   },
   {
+    "Name": "Delete - Single file find project C#",
+    "ExpectedResults": [
+      {
+        "ResultCode": 0,
+        "DiscoveredProject": "snippets/good/normal/csharp_project/app1.csproj"
+      }
+    ],
+    "Items": [
+      {
+        "ItemType": "Delete",
+        "Path": "snippets/good/normal/csharp_project/DeletedFile.cs"
+      }
+    ]
+  },
+  {
     "Name": "Delete - All files, artifact remains in folder",
     "ExpectedResults": [
       {
@@ -285,7 +315,7 @@
     "Items": [
       {
         "ItemType": "Edit",
-        "Path": "snippets/bad/nullablepatternmatching/Program.cs"
+        "Path": "snippets/bad/nullablepatternmatching/childwithcode/Program.cs"
       }
     ]
   },

--- a/snippets5000/PullRequestSimulations/snippets/bad/nullablepatternmatching/childwithcode/Program.cs
+++ b/snippets5000/PullRequestSimulations/snippets/bad/nullablepatternmatching/childwithcode/Program.cs
@@ -1,0 +1,58 @@
+﻿// <SnippetPatternMatchingNullable>
+int i = 5;
+PatternMatchingNullable(i);
+
+int? j = null;
+PatternMatchingNullable(j);
+
+double d = 9.78654;
+PatternMatchingNullable(d);
+
+PatternMatchingSwitch(i);
+PatternMatchingSwitch(j);
+PatternMatchingSwitch(d);
+
+static void PatternMatchingNullable(ValueType? val)
+{
+    if (val is int j) // Nullable types are not allowed in patterns
+    {
+        Console.WriteLine(j);
+    }
+    else if (val is null) // If val is a nullable type with no value, this expression is true
+    {
+        Console.WriteLine("val is a nullable type with the null value");
+    }
+    else
+    {
+        Console.WriteLine("Could not convert " + val.ToString());
+    }
+}
+
+static void PatternMatchingSwitch(ValueType? val)
+{
+    switch (val)
+    {
+        case int number:
+            Console.WriteLine(number);
+            break;
+        case long number:
+            Console.WriteLine(number);
+            break;
+        case decimal number:
+            Console.WriteLine(number);
+            break;
+        case float number:
+            Console.WriteLine(number);
+            break;
+        case double number:
+            Console.WriteLine(number);
+            break;
+        case null:
+            Console.WriteLine("val is a nullable type with the null value");
+            break;
+        default:
+            Console.WriteLine("Could not convert " + val.ToString());
+            break;
+    }
+}
+// </SnippetPatternMatchingNullable>

--- a/snippets5000/PullRequestSimulations/snippets/good/normal/single_code_file/Now.cs
+++ b/snippets5000/PullRequestSimulations/snippets/good/normal/single_code_file/Now.cs
@@ -1,2 +1,2 @@
 ﻿#!/usr/local/share/dotnet/dotnet run
-Console.WriteLine2("Now: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));
+Console.WriteLine("Now: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));

--- a/snippets5000/PullRequestSimulations/snippets/good/normal/single_code_file/Now.cs
+++ b/snippets5000/PullRequestSimulations/snippets/good/normal/single_code_file/Now.cs
@@ -1,0 +1,2 @@
+﻿#!/usr/local/share/dotnet/dotnet run
+Console.WriteLine2("Now: " + DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"));

--- a/snippets5000/Snippets5000/Program.cs
+++ b/snippets5000/Snippets5000/Program.cs
@@ -4,6 +4,7 @@ using System.Text.RegularExpressions;
 using System.Text.Json;
 using static Snippets5000.SnippetsConfigFile;
 using Log = DotNet.DocsTools.Utility.EchoLogging;
+using DotNet.DocsTools.Utility;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("PullRequestSimulations")]
 
@@ -337,6 +338,7 @@ class Program
                 config.RunOutput = config.RunOutput.Trim();
                 Log.Write(2, $"Output:");
                 Log.Write(4, config.RunOutput.Replace("\n", $"\n{Log.Ind(4)}"));
+                Log.Write(4, $"Exit code: {config.RunExitCode}");
             }
 
             Log.EndGroup();


### PR DESCRIPTION
Added detection for a single C# file in a directory with no other code files or projects above or below it. When this is triggered, it uses the C# file name as the project name, which lets us run `dotnet build file.cs`.

If the host is running .NET 9 or below, this just results in a compiler error because file.cs isn't a project, as expected. If the host is running .NET 10 or above, the compile runs normally and the only error reported is a true compiler error.

I added two additional tests (note that tests don't compile and check that portion of the project, they only test the detection engine):
- **Edit - Single file no project - Compile** which tests the new .NET 10 projectless compile.
- **Delete - Single file find project C#** which tests deleting a single file from a directory with a project and some other code file. This doesn't test anything new, it was just previously omitted.