### PR TITLE
Remove check for `hasChildren`

### DIFF
--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -226,7 +226,6 @@ public class QuestGitHubService(
 
         var parentIteration = sprintPackets.Descendent("value").EnumerateArray().Single(i => i.GetProperty("structureType").GetString() == "iteration");
 
-
         return [.. ChildIterations(parentIteration)];
 
         static IEnumerable<QuestIteration> ChildIterations(JsonElement parentIteration)
@@ -240,7 +239,7 @@ public class QuestGitHubService(
                         yield return child;
                     }
                 }
-                else if (sprintElement.GetProperty("hasChildren").GetBoolean() == false)
+                else
                 {
                     var iteration = ConstructIteration(sprintElement);
                     if (iteration is not null)


### PR DESCRIPTION
The current iteration has the flag for "hasChildren" set to true, even though it has no children.

But, because that flag was set, it was filtered out of the possible values for an iteration.

This fix does mean some very old values are included in the list of "all iterations". Those don't match any of the current patterns, so I chose the smallest code change possible. This logic could be modified to remove iterations from old patterns, but that seems unnecessary at this time.