### PR TITLE
Fix issue with default parent

### DIFF
--- a/actions/sequester/ImportIssues/Program.cs
+++ b/actions/sequester/ImportIssues/Program.cs
@@ -119,6 +119,7 @@ internal class Program
                 options.ImportedLabel,
                 options.UnlinkLabel,
                 options.ParentNodes,
+                options.DefaultParentNode,
                 options.WorkItemTags,
                 options.TeamGitHubLogins,
                 options.CopilotIssueTag);

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -671,7 +671,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Content\\Future", extendedProperties.IterationPath);
         Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
-        Assert.Equal(0, extendedProperties.ParentNodeId);
+        Assert.Equal(33, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -698,7 +698,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Content\\Future", extendedProperties.IterationPath);
         Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Equal(["content-curation"], extendedProperties.Tags);
-        Assert.Equal(0, extendedProperties.ParentNodeId);
+        Assert.Equal(33, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -712,7 +712,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Content\\Future", extendedProperties.IterationPath);
         Assert.Equal("New", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
-        Assert.Equal(0, extendedProperties.ParentNodeId);
+        Assert.Equal(33, extendedProperties.ParentNodeId);
     }
 
     [Fact]
@@ -726,7 +726,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal("Content\\Future", extendedProperties.IterationPath);
         Assert.Equal("Closed", extendedProperties.WorkItemState);
         Assert.Empty(extendedProperties.Tags);
-        Assert.Equal(0, extendedProperties.ParentNodeId);
+        Assert.Equal(33, extendedProperties.ParentNodeId);
     }
 
     private static WorkItemProperties CreateIssueObject(string jsonDocument)
@@ -738,7 +738,7 @@ public class BuildExtendedPropertiesTests
             issueNumber = 1111
         };
         JsonElement element = JsonDocument.Parse(jsonDocument).RootElement;
-        return new WorkItemProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap, "copilotTag");
+        return new WorkItemProperties(QuestIssue.FromJsonElement(element, variables), _allIterations, _tagMap, _parentMap, _defaultParentId, "copilotTag");
     }
 
 }

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -22,6 +22,7 @@ public class WorkItemProperties
         IEnumerable<QuestIteration> iterations,
         IEnumerable<LabelToTagMap> tags,
         IEnumerable<ParentForLabel> parentNodes,
+        int defaultParentNodeId,
         string copilotTag)
     {
         StoryPointSize? storySize = LatestStoryPointSize(issue);
@@ -41,7 +42,7 @@ public class WorkItemProperties
         };
         IterationPath = latestIteration.Path;
 
-        ParentNodeId = 0;
+        ParentNodeId = defaultParentNodeId;
 
         if (WorkItemState is not "New")
         {

--- a/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
+++ b/actions/sequester/Quest2GitHub/Options/ImportOptions.cs
@@ -73,6 +73,11 @@ public sealed record class ImportOptions
     public List<ParentForLabel> ParentNodes { get; init; } = [];
 
     /// <summary>
+    /// The default parent node ID to use when no other parent has been configured.
+    /// </summary>
+    public int DefaultParentNode { get; init; } = 0;
+
+    /// <summary>
     /// A map of GitHub labels to Azure DevOps tags.
     /// </summary>
     /// <remarks>

--- a/actions/sequester/Quest2GitHub/QuestGitHubService.cs
+++ b/actions/sequester/Quest2GitHub/QuestGitHubService.cs
@@ -40,6 +40,7 @@ public class QuestGitHubService(
     string importedLabelText,
     string removeLinkItemText,
     List<ParentForLabel> parentNodes,
+    int defaultParentNodeId,
     IEnumerable<LabelToTagMap> tagMap,
     IEnumerable<string> gitHubLogins,
     string copilotTag) : IDisposable
@@ -97,7 +98,7 @@ public class QuestGitHubService(
                     QuestWorkItem? questItem = (request || sequestered || vanquished)
                         ? await FindLinkedWorkItemAsync(item)
                         : null;
-                    var issueProperties = new WorkItemProperties(item, _allIterations, tagMap, parentNodes, copilotTag);
+                    var issueProperties = new WorkItemProperties(item, _allIterations, tagMap, parentNodes, defaultParentNodeId, copilotTag);
 
                     Console.WriteLine($"{item.Number}: {item.Title}, {issueProperties.IssueLogString}");
                     Task workDone = (request, sequestered, vanquished, questItem) switch
@@ -184,7 +185,7 @@ public class QuestGitHubService(
             ? await FindLinkedWorkItemAsync(ghIssue)
             : null;
 
-        var issueProperties = new WorkItemProperties(ghIssue, _allIterations, tagMap, parentNodes, copilotTag);
+        var issueProperties = new WorkItemProperties(ghIssue, _allIterations, tagMap, parentNodes, defaultParentNodeId, copilotTag);
 
         Task workDone = (request, sequestered, vanquished, questItem) switch
         {


### PR DESCRIPTION
When an item wasn't in a semester, and it had no tag for a given section, the parent defaulted to 0, not the default parent ID in the config.

Update tests to catch that, then update code to match the new behavior.