### PR TITLE
Exclude test pkg and buggy pkg

### DIFF
--- a/PackageIndexer/PlatformPackageDefinition.cs
+++ b/PackageIndexer/PlatformPackageDefinition.cs
@@ -120,7 +120,7 @@ internal static class PlatformPackageDefinition
             PackageFilterExpression.Parse("Microsoft.Extensions.ServiceDiscovery*"),
             // Caused failure on 5/12/26 - see https://apidrop.visualstudio.com/6fb8cb7d-5623-420c-946b-ca74e63ac8ba/_apis/build/builds/607248/logs/34
             PackageFilterExpression.Parse("Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"),
-            // Tests package - checking with Shay R. 5/12/26
+            // Public pkg but purely meant as a provider-facing helper.
             PackageFilterExpression.Parse("Microsoft.Extensions.VectorData.ConformanceTests"),
             // Old R9 packages.
             PackageFilterExpression.Parse("Microsoft.Extensions.DependencyInjection.NamedService"),

--- a/PackageIndexer/PlatformPackageDefinition.cs
+++ b/PackageIndexer/PlatformPackageDefinition.cs
@@ -118,6 +118,10 @@ internal static class PlatformPackageDefinition
             PackageFilterExpression.Parse("Microsoft.Extensions.ML"),
             // Documented under .NET Aspire moniker.
             PackageFilterExpression.Parse("Microsoft.Extensions.ServiceDiscovery*"),
+            // Caused failure on 5/12/26 - see https://apidrop.visualstudio.com/6fb8cb7d-5623-420c-946b-ca74e63ac8ba/_apis/build/builds/607248/logs/34
+            PackageFilterExpression.Parse("Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"),
+            // Tests package - checking with Shay R. 5/12/26
+            PackageFilterExpression.Parse("Microsoft.Extensions.VectorData.ConformanceTests"),
             // Old R9 packages.
             PackageFilterExpression.Parse("Microsoft.Extensions.DependencyInjection.NamedService"),
             PackageFilterExpression.Parse("Microsoft.Extensions.DependencyInjection.Pools"),

--- a/PackageIndexer/PlatformPackageDefinition.cs
+++ b/PackageIndexer/PlatformPackageDefinition.cs
@@ -118,7 +118,7 @@ internal static class PlatformPackageDefinition
             PackageFilterExpression.Parse("Microsoft.Extensions.ML"),
             // Documented under .NET Aspire moniker.
             PackageFilterExpression.Parse("Microsoft.Extensions.ServiceDiscovery*"),
-            // Caused failure on 5/12/26 - see https://apidrop.visualstudio.com/6fb8cb7d-5623-420c-946b-ca74e63ac8ba/_apis/build/builds/607248/logs/34
+            // Fails to install in the CI pipeline - tracked by https://dev.azure.com/ceapex/Engineering/_workitems/edit/1146088.
             PackageFilterExpression.Parse("Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore"),
             // Public pkg but purely meant as a provider-facing helper.
             PackageFilterExpression.Parse("Microsoft.Extensions.VectorData.ConformanceTests"),


### PR DESCRIPTION
MEVD.ConformanceTests is purely meant as a provider-facing helper, per Shay.

 HealthChecks.EntityFrameworkCore fails to install in the CI pipeline - tracked by https://dev.azure.com/ceapex/Engineering/_workitems/edit/1146088.