### PR TITLE
Support tags with replaceable text

### DIFF
--- a/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
+++ b/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
@@ -98,22 +98,18 @@ public record StoryPointSize
     public string Size { get; }
     public int? Priority { get; }
 
-    public string FullMonthText => Month switch
+    public string FullMonthText
     {
-        "Jan" => "January",
-        "Feb" => "February",
-        "Mar" => "March",
-        "Apr" => "April",
-        "May" => "May",
-        "Jun" => "June",
-        "Jul" => "July",
-        "Aug" => "August",
-        "Sep" => "September",
-        "Oct" => "October",
-        "Nov" => "November",
-        "Dec" => "December",
-        _ => Month
-    };
+        get
+        {
+            if (!TryGetMonthOrdinal(Month, out int ordinal))
+            {
+                return Month;
+            }
+
+            return System.Globalization.CultureInfo.InvariantCulture.DateTimeFormat.GetMonthName(ordinal);
+        }
+    }
 
     public bool IsPastIteration
     {

--- a/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
+++ b/DotNet.DocsTools/GitHubObjects/StoryPointSize.cs
@@ -98,6 +98,23 @@ public record StoryPointSize
     public string Size { get; }
     public int? Priority { get; }
 
+    public string FullMonthText => Month switch
+    {
+        "Jan" => "January",
+        "Feb" => "February",
+        "Mar" => "March",
+        "Apr" => "April",
+        "May" => "May",
+        "Jun" => "June",
+        "Jul" => "July",
+        "Aug" => "August",
+        "Sep" => "September",
+        "Oct" => "October",
+        "Nov" => "November",
+        "Dec" => "December",
+        _ => Month
+    };
+
     public bool IsPastIteration
     {
         get

--- a/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
+++ b/actions/sequester/Quest2GitHub.Tests/BuildExtendedPropertiesTests.cs
@@ -26,6 +26,7 @@ public class BuildExtendedPropertiesTests
     [
         new () { Label = ":checkered_flag: Release: .NET 9", Tag = "new-feature" },
         new () { Label = labelForTag, Tag = "content-curation" },
+        new () { Label = labelWithReplacement, Tag = "Highlight-$FullMonthText$" }
     ];
 
     private static ParentForLabel[] _parentMap =
@@ -40,6 +41,8 @@ public class BuildExtendedPropertiesTests
     private const string labelWithoutTag = "enhancement";
     private const string labelWithParent = "user-feedback";
     private const string labelWithoutParent = "bug";
+
+    private const string labelWithReplacement = ":sparkler: Highlight :sparkler:";
 
 
     private const string PastProject = """
@@ -257,12 +260,12 @@ public class BuildExtendedPropertiesTests
       "labels": {
         "nodes": [
           {
-            "name": "{{labelForTag}}",
-            "id": "MDU6TGFiZWwzMDkwMTEzMzI1"
-          },
-          {
             "name": "{{labelWithoutTag}}",
             "id": "LA_kwDOFn2dfM8AAAABK0cMjA"
+          },
+          {
+            "name": "{{labelWithReplacement}}",
+            "id": "NA"
           }
         ]
       },
@@ -665,7 +668,7 @@ public class BuildExtendedPropertiesTests
         Assert.Equal(2, extendedProperties.Priority);
         Assert.Equal(ExpectedFutureProject, extendedProperties.IterationPath);
         Assert.Equal("New", extendedProperties.WorkItemState);
-        Assert.Equal(["content-curation"], extendedProperties.Tags);
+        Assert.Equal(["Highlight-March"], extendedProperties.Tags);
         Assert.Equal(33, extendedProperties.ParentNodeId);
     }
 

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -186,9 +186,9 @@ public class WorkItemProperties
         foreach (var label in issue.Labels)
         {
             var tag = tags.FirstOrDefault(t => t.Label == label.Name);
-            if (tag.Tag is not null)
+            if ((tag.Tag is not null) && (sprint is not null))
             {
-                yield return (sprint is not null) ? tag.Tag.Replace("$FullMonthText$", sprint) : tag.Tag;
+                yield return tag.Tag.Replace("$FullMonthText$", sprint);
             }
         }
         // Add custom tag if one of the assignees is "Copilot":

--- a/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
+++ b/actions/sequester/Quest2GitHub/Models/WorkItemProperties.cs
@@ -182,12 +182,13 @@ public class WorkItemProperties
 
     private static IEnumerable<string> WorkItemTagsForIssue(QuestIssueOrPullRequest issue, IEnumerable<LabelToTagMap> tags, string copilotTag)
     {
+        string? sprint = LatestStoryPointSize(issue)?.FullMonthText?.ToString();
         foreach (var label in issue.Labels)
         {
             var tag = tags.FirstOrDefault(t => t.Label == label.Name);
             if (tag.Tag is not null)
             {
-                yield return tag.Tag;
+                yield return (sprint is not null) ? tag.Tag.Replace("$FullMonthText$", sprint) : tag.Tag;
             }
         }
         // Add custom tag if one of the assignees is "Copilot":

--- a/quest-config.json
+++ b/quest-config.json
@@ -6,5 +6,19 @@
     },
     "ImportTriggerLabel": ":world_map: reQUEST",
     "ImportedLabel": ":pushpin: seQUESTered",
-    "DefaultParentNode": 405108
+    "DefaultParentNode": 405108,
+    "WorkItemTags": [
+        {
+            "Label": ":sparkler: Highlight :sparkler:",
+            "Tag": "Highlight-$FullMonthText$"
+        },
+        {
+            "Label": ":mag_right: AISDLC :mag:",
+            "Tag": "SP-AISDLC"
+        },
+        {
+            "Label": ":mag_right: AIPlatform :mag:",
+            "Tag": "SP-AIPlatform"
+        }
+    ]
 }


### PR DESCRIPTION
Currently small in scope, this adds a way to map a label to a tag, including some replacement text. For now, this handles monthly highlights.

Update the config with new label -> tag mapping for spotlight projects and monthly highlights. So we don't have to change the config every month, this maps a general "Highlight" label to a "Highlight-<Month>" tag in Azure DevOps.